### PR TITLE
sort comments of a place by newest first

### DIFF
--- a/lib/functions_place.php
+++ b/lib/functions_place.php
@@ -328,8 +328,9 @@ function get_comments($id=false, $limit=false) {
 	
 	// Query with limit
 	if($limit !== false && !empty($limit)) $query .= " LIMIT ".mysql_real_escape_string($limit);
-	
-	$query .= " ORDER BY `datetime` ASC";
+
+	// Sort by newest first
+	$query .= " ORDER BY `datetime` DESC";
 	
 	// Build an array
    	$res = mysql_query($query);


### PR DESCRIPTION
Otherwise you are confused when you see old stuff first (about station being closed, construction work, etc.) which might be outdated. This is especially annoying when there are 10+ comments and you have to scroll through it to see the latest info.

This change fixes that problem with a simple reversal of the sort order from datetime ASC to DESC.

cc @simison @guaka