### PR TITLE
Long-press / right-click to drop a pin and add a hitch site

### DIFF
--- a/docs/superpowers/specs/2026-06-28-longpress-add-hitch-site-design.md
+++ b/docs/superpowers/specs/2026-06-28-longpress-add-hitch-site-design.md
@@ -1,0 +1,176 @@
+# Long-press / right-click to add a hitch site — Design
+
+**Date:** 2026-06-28
+**Status:** Approved (design)
+**Scope:** Frontend only — `hitch/static/map.js`. No backend, template, or service-worker changes.
+
+## Goal
+
+On the map (primarily the mobile PWA saved to the homescreen, but also desktop), let the
+user drop a pin at an arbitrary point and open the existing ride-submission form pre-filled
+with that point as the pickup location, so they can add a hitch site to the database.
+
+- **Touch:** long-press the map.
+- **Desktop:** right-click (contextmenu) the map.
+
+## Context / existing infrastructure being reused
+
+The map already has a complete draggable-marker location-selection mode, used today when a
+user picks the pickup/destination location from the ride form:
+
+- Hash route `#select-pickup/<lat,lon,zoom>` (and `select-destination`) is handled in the
+  hashchange/navigate logic at `hitch/static/map.js:1410`, which calls `setupLocationSelection`.
+- `setupLocationSelection(selectionType, coordsArg)` (`map.js` ~2070) drops a **draggable**
+  red marker, lets a map click reposition it, and renders a fixed white panel with
+  **Confirm Location** / **Cancel** buttons.
+- `confirmLocationSelection()` (`map.js:2119`) reads the marker latlng, writes
+  `pickup_lat`/`pickup_lon` (or destination) into `sessionStorage.rideFormData`, and
+  navigates to `/ride` (or `/ride?edit=<d_tag>` when editing).
+- `cancelLocationSelection()` (`map.js:2142`) cleans up and navigates back to `/ride`.
+- The ride form (`hitch/templates/ride_form.html`, `restoreFormData()` ~397) reads
+  `sessionStorage.rideFormData` on load and pre-fills the pickup location from it.
+
+The ride form already supports **anonymous** submission, so no authentication gating is needed.
+
+The service worker (`hitch/static/sw.js`) is **network-first** for non-image resources
+(scripts included), so the updated `map.js` propagates to the installed PWA on the next
+online load. **No cache-version bump is required.**
+
+## Approach
+
+Chosen approach (A): trigger the existing selection-mode machinery from a gesture instead of
+from a hash arriving from the form. This keeps a single, proven selection/confirm code path.
+
+## Design
+
+### 1. Gesture detection (new listeners attached where the map is initialized)
+
+**Touch long-press:**
+- On `touchstart`: if exactly one touch, record the touch client point and start a timer
+  (`LONG_PRESS_MS = 500`).
+- Cancel the timer on:
+  - `touchmove` where the touch moves more than a small threshold
+    (`MOVE_CANCEL_PX = 10`) from the start point — so map panning never triggers it;
+  - `touchend`/`touchcancel` before the timer fires;
+  - a second touch starting (pinch-zoom).
+- When the timer fires: convert the recorded point to a Leaflet container point and latlng
+  (`map.containerPointToLatLng`), call `startAddSpotFromGesture(latlng, containerPoint)`, and
+  suppress the default callout/selection (`preventDefault` on the originating event where
+  possible).
+
+**Desktop right-click:**
+- `map.on('contextmenu', (e) => { e.originalEvent.preventDefault();
+  startAddSpotFromGesture(e.latlng, e.containerPoint); })`.
+  Leaflet provides `e.latlng` and `e.containerPoint`; prevent the browser context menu.
+
+The gesture must not interfere with existing marker clicks (`marker.on("click", …)`),
+filter-pane interactions, or panning/zoom. Long-press on top of an existing marker is
+acceptable — the user can drag the resulting pin or cancel.
+
+### 2. Enter selection mode at the pressed point (with snap-to-existing-spot)
+
+New function `startAddSpotFromGesture(latlng, containerPoint)`:
+1. `sessionStorage.removeItem('rideFormData')` — start a **fresh** ride: no edit mode, no
+   stale fields from a previous session.
+2. **Snap check:** call `findNearbySpotMarker(containerPoint)` (see §2a). If it returns a
+   marker, use that marker's exact `getLatLng()` as the seed location and flag the add as an
+   *existing-spot* add; otherwise use the raw `latlng` as a *new-spot* add.
+3. Enter the selection mode seeded at the chosen location (see §3):
+   effectively `setupLocationSelection('select-pickup', null,
+   { initialLatLng: seedLatLng, isNewSpot: true, existingSpot: <bool> })`.
+
+No hash round-trip is required; the function is called directly.
+
+Snapping to the marker's **exact** lat/lon is important: spot IDs are derived from lat/lon at
+5 decimals (`generate_spot_id` in `show.py`, mirrored at `map.js:96`), so a ride seeded at the
+exact coords merges into the same spot rather than creating a near-duplicate anchor.
+
+### 2a. `findNearbySpotMarker(containerPoint, thresholdPx = 22)`
+
+New helper that returns the nearest existing spot marker to a screen point, or `null`:
+- Iterate the global `allMarkers` array (populated in `loadMarkers`).
+- **Skip clustered markers:** below `disableClusteringAtZoom` (7) markers are hidden inside
+  clusters. Skip any marker whose visible parent is a cluster
+  (`markerCluster.getVisibleParent(marker) !== marker`) so we only snap to a pin the user can
+  actually see. This requires `markerCluster` to be reachable from the helper — promote the
+  currently-local `markerCluster` (in `loadMarkers`) to a module-scope variable.
+- For each remaining marker, compute the pixel distance between
+  `map.latLngToContainerPoint(marker.getLatLng())` and `containerPoint`.
+- Return the closest marker whose distance `<= thresholdPx`, else `null`.
+
+The desktop `contextmenu` handler supplies `containerPoint` from
+`map.latLngToContainerPoint(e.latlng)` (or `e.containerPoint` if available); the touch handler
+computes it from the recorded touch point.
+
+### 3. Refactor `setupLocationSelection`
+
+Extend the signature to accept optional behavior without changing existing callers:
+
+- New optional `opts = { initialLatLng, isNewSpot }`.
+- When `opts.initialLatLng` is provided, place the draggable marker there (instead of map
+  center / parsed coords). Existing form-driven callers pass no opts and keep current behavior.
+- When `opts.isNewSpot` is true, relabel the confirm panel:
+  - If `opts.existingSpot` (snapped to an existing pin):
+    - Heading: **"Add a ride to this spot"**
+    - Instruction: **"This matches an existing hitch spot. Confirm to add your ride here."**
+    - Confirm button text: **"Add ride"**.
+  - Otherwise (fresh point):
+    - Heading: **"Add a hitch spot here?"**
+    - Instruction: **"Drag the pin to fine-tune, then confirm."**
+    - Confirm button text: **"Add spot"**.
+  - When neither flag is set, keep the existing "Select Pickup/Destination Location" copy.
+- Persist the `isNewSpot` flag alongside the existing `locationSelectionType` module state so
+  confirm/cancel can branch on it. (`existingSpot` only affects panel copy, not confirm/cancel
+  behavior — a snapped pin is still draggable, and dragging away from the spot simply creates a
+  new one.)
+
+### 4. Confirm / Cancel
+
+- **Confirm** (`confirmLocationSelection`): unchanged logic — write `pickup_lat`/`pickup_lon`
+  into `rideFormData` and navigate to `/ride`. Because `rideFormData` was cleared in §2 and
+  there is no `edit_d_tag`, the form opens fresh with only the pickup pre-filled.
+- **Cancel** (`cancelLocationSelection`): branch on the new-spot flag.
+  - New-spot mode: clean up the marker/panel and **return to the map** (remove the marker,
+    remove the UI, clear any selection hash via `history.replaceState`). Do **not** navigate
+    to `/ride`.
+  - Form-driven mode: unchanged (navigate back to `/ride`, preserving edit mode).
+
+### 5. Module state / cleanup
+
+- Reuse existing `locationSelectionMarker` / `locationSelectionType` module variables; add a
+  `locationSelectionIsNewSpot` (or fold into an options object) for the branch.
+- `cleanupLocationSelection` continues to remove the marker, remove the panel, and detach the
+  temporary `map.on('click')` handler; ensure the new-spot path calls it.
+
+## Out of scope (YAGNI)
+
+- No new lightweight modal or new "add spot" page — reuse the existing `/ride` form.
+- No reverse-geocoding / address lookup of the pressed point.
+- No new backend endpoint or model changes (submission goes through the existing form/POST).
+- No service-worker changes.
+
+## Testing / verification (manual)
+
+There is no JS test harness in the repo (tests are pytest/Python), so verification is manual
+in the browser and the installed PWA:
+
+1. **Desktop right-click** on an empty map area → draggable pin + "Add a hitch spot here?"
+   panel appears at the clicked point; browser context menu does not appear.
+2. **Mobile long-press** (touch device / emulation) on the map → same pin + panel at the
+   pressed point.
+3. **Drag** the pin → position updates; tapping the map also repositions it.
+4. **Confirm ("Add spot")** → navigates to `/ride` with the pickup location pre-filled to the
+   pin location and the rest of the form empty.
+5. **Cancel** → returns to the map (pin and panel removed), no navigation to `/ride`.
+6. **Snap to existing pin:** long-press/right-click directly on (or within ~22px of) an
+   existing spot marker → the pin seeds at that marker's exact location and the panel reads
+   "Add a ride to this spot". Confirm → `/ride` with pickup at the spot's coords, so the ride
+   merges into that spot.
+7. **No false snap:** pressing in empty space well away from any marker → "Add a hitch spot
+   here?" (no snap).
+8. **No snap to clustered pins:** at a low zoom where spots are clustered, pressing on a
+   cluster does **not** snap to a hidden marker.
+9. **Panning** (touch drag) does **not** trigger the long-press.
+10. **Pinch-zoom** (two fingers) does **not** trigger the long-press.
+11. The existing form-driven "select pickup/destination on map" flow still works unchanged.
+12. In the installed PWA, after an online load, the new gesture is available (network-first SW).

--- a/docs/superpowers/specs/2026-06-28-longpress-add-hitch-site-design.md
+++ b/docs/superpowers/specs/2026-06-28-longpress-add-hitch-site-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-28
 **Status:** Approved (design)
-**Scope:** Frontend only — `hitch/static/map.js`. No backend, template, or service-worker changes.
+**Scope:** Frontend only — `hitch/static/map.js`, `hitch/static/style.css`, and `hitch/templates/map.html`. No backend or service-worker changes.
 
 ## Goal
 

--- a/hitch/static/map.js
+++ b/hitch/static/map.js
@@ -2128,27 +2128,20 @@ function setupLocationSelection(selectionType, initialCoords, opts = {}) {
         confirmLabel = 'Confirm Location';
     }
 
-    // Add custom UI for location selection
+    // Add custom UI for location selection — a compact card pinned to the bottom
+    // (styled in style.css under .location-selection-ui) so it never covers the
+    // top search bar. The body class hides the bottom action pane while selecting.
     const selectionUI = L.DomUtil.create('div', 'location-selection-ui');
     selectionUI.innerHTML = `
-        <div style="position: fixed; top: 20px; left: 50%; transform: translateX(-50%);
-                    background: white; padding: 15px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-                    z-index: 1000; text-align: center; min-width: 300px;">
-            <h4 style="margin: 0 0 10px 0;">${heading}</h4>
-            <p style="margin: 0 0 15px 0; font-size: 14px; color: #666;">
-                ${instruction}
-            </p>
-            <button onclick="confirmLocationSelection()" style="background: #007bff; color: white; border: none;
-                           padding: 8px 20px; border-radius: 4px; margin-right: 10px; cursor: pointer;">
-                ${confirmLabel}
-            </button>
-            <button onclick="cancelLocationSelection()" style="background: #6c757d; color: white; border: none;
-                           padding: 8px 20px; border-radius: 4px; cursor: pointer;">
-                Cancel
-            </button>
+        <h4>${heading}</h4>
+        <p>${instruction}</p>
+        <div class="lsel-actions">
+            <button class="lsel-confirm" onclick="confirmLocationSelection()">${confirmLabel}</button>
+            <button class="lsel-cancel" onclick="cancelLocationSelection()">Cancel</button>
         </div>
     `;
     document.body.appendChild(selectionUI);
+    document.body.classList.add('selecting-location');
 }
 
 function confirmLocationSelection() {
@@ -2203,6 +2196,7 @@ function cleanupLocationSelection() {
     if (ui) {
         ui.remove();
     }
+    document.body.classList.remove('selecting-location');
 
     // Remove only our reposition handler — a bare map.off('click') would also
     // detach handleMapClick, which matters when we stay on the map after cancel.

--- a/hitch/static/map.js
+++ b/hitch/static/map.js
@@ -21,6 +21,7 @@ var allMarkers = [],
   normalLayer = null,
   heatmapLegend = null,
   spotsData = null,
+  markerCluster = null,
   ridesIndex = null;
 
 // Create the Leaflet map synchronously so controls are in their final position immediately
@@ -55,7 +56,9 @@ async function loadMarkers(map) {
   return fetch(url)
     .then((response) => response.json())
     .then((data) => {
-      var markerCluster = L.markerClusterGroup({
+      // Module-scoped so findNearbySpotMarker() can ask whether a marker is
+      // currently hidden inside a cluster (getVisibleParent) when snapping.
+      markerCluster = L.markerClusterGroup({
         disableClusteringAtZoom: 7,
         spiderfyOnMaxZoom: false,
       });
@@ -369,6 +372,9 @@ function setupEventListeners() {
   map.on("zoom", () =>
     document.body.classList.toggle("zoomed-out", map.getZoom() < 9)
   );
+
+  // Long-press (touch) / right-click (desktop) drops a pin to add a hitch site.
+  setupAddSpotGesture();
 
   clearFilters.onclick = () => {
     clearParams();
@@ -2059,10 +2065,17 @@ function confirmClaimReview(url) {
 // Location selection functionality for ride form
 let locationSelectionMarker = null;
 let locationSelectionType = null;
+// True when selection was started from a map gesture (add a new hitch site) rather
+// than from the ride form's "pick location" flow — controls cancel behavior and copy.
+let locationSelectionIsNewSpot = false;
+// Stored so cleanup removes only this handler (map.off('click') with no function
+// would strip handleMapClick too, breaking the map when we stay on it after cancel).
+let locationSelectionClickHandler = null;
 
-function setupLocationSelection(selectionType, initialCoords) {
+function setupLocationSelection(selectionType, initialCoords, opts = {}) {
     locationSelectionType = selectionType;
-    
+    locationSelectionIsNewSpot = !!opts.isNewSpot;
+
     // Parse initial coordinates if provided
     if (initialCoords) {
         const coords = initialCoords.split(',');
@@ -2073,10 +2086,11 @@ function setupLocationSelection(selectionType, initialCoords) {
             map.setView([lat, lon], zoom);
         }
     }
-    
-    // Add a draggable marker for location selection
-    const center = map.getCenter();
-    locationSelectionMarker = L.marker(center, {
+
+    // Place the draggable marker at the explicit seed location (gesture-initiated
+    // add) when given, otherwise at the current map center (form-initiated pick).
+    const markerLatLng = opts.initialLatLng || map.getCenter();
+    locationSelectionMarker = L.marker(markerLatLng, {
         draggable: true,
         icon: L.icon({
             iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png',
@@ -2087,27 +2101,48 @@ function setupLocationSelection(selectionType, initialCoords) {
             shadowSize: [41, 41]
         })
     }).addTo(map);
-    
-    // Update marker position when map is clicked
-    map.on('click', function(e) {
+
+    // Update marker position when map is clicked (kept in a named handler so
+    // cleanup can detach only this one — see locationSelectionClickHandler).
+    locationSelectionClickHandler = function(e) {
         locationSelectionMarker.setLatLng(e.latlng);
-    });
-    
+    };
+    map.on('click', locationSelectionClickHandler);
+
+    // Panel copy: gesture-initiated adds get add-a-site wording (and a distinct
+    // variant when snapped onto an existing spot); the form-initiated pick keeps
+    // the original "Select Pickup/Destination Location" copy.
+    let heading, instruction, confirmLabel;
+    if (opts.isNewSpot && opts.existingSpot) {
+        heading = 'Add a ride to this spot';
+        instruction = 'This matches an existing hitch spot. Confirm to add your ride here.';
+        confirmLabel = 'Add ride';
+    } else if (opts.isNewSpot) {
+        heading = 'Add a hitch spot here?';
+        instruction = 'Drag the pin to fine-tune, then confirm.';
+        confirmLabel = 'Add spot';
+    } else {
+        const what = selectionType === 'select-pickup' ? 'Pickup' : 'Destination';
+        heading = `Select ${what} Location`;
+        instruction = `Click on the map or drag the marker to choose your ${what.toLowerCase()} location`;
+        confirmLabel = 'Confirm Location';
+    }
+
     // Add custom UI for location selection
     const selectionUI = L.DomUtil.create('div', 'location-selection-ui');
     selectionUI.innerHTML = `
-        <div style="position: fixed; top: 20px; left: 50%; transform: translateX(-50%); 
+        <div style="position: fixed; top: 20px; left: 50%; transform: translateX(-50%);
                     background: white; padding: 15px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.3);
                     z-index: 1000; text-align: center; min-width: 300px;">
-            <h4 style="margin: 0 0 10px 0;">Select ${selectionType === 'select-pickup' ? 'Pickup' : 'Destination'} Location</h4>
+            <h4 style="margin: 0 0 10px 0;">${heading}</h4>
             <p style="margin: 0 0 15px 0; font-size: 14px; color: #666;">
-                Click on the map or drag the marker to choose your ${selectionType === 'select-pickup' ? 'pickup' : 'destination'} location
+                ${instruction}
             </p>
-            <button onclick="confirmLocationSelection()" style="background: #007bff; color: white; border: none; 
+            <button onclick="confirmLocationSelection()" style="background: #007bff; color: white; border: none;
                            padding: 8px 20px; border-radius: 4px; margin-right: 10px; cursor: pointer;">
-                Confirm Location
+                ${confirmLabel}
             </button>
-            <button onclick="cancelLocationSelection()" style="background: #6c757d; color: white; border: none; 
+            <button onclick="cancelLocationSelection()" style="background: #6c757d; color: white; border: none;
                            padding: 8px 20px; border-radius: 4px; cursor: pointer;">
                 Cancel
             </button>
@@ -2140,10 +2175,18 @@ function confirmLocationSelection() {
 }
 
 function cancelLocationSelection() {
-    // Clean up and return to ride form without changing coordinates
+    const wasNewSpot = locationSelectionIsNewSpot;
+
+    // Clean up without changing coordinates
     cleanupLocationSelection();
 
-    // Return to ride form, preserving edit mode if editing an existing ride
+    // Gesture-initiated add: the user never left the map, so just stay here.
+    if (wasNewSpot) {
+        history.replaceState(null, null, " ");
+        return;
+    }
+
+    // Form-initiated pick: return to ride form, preserving edit mode if editing.
     const formData = JSON.parse(sessionStorage.getItem('rideFormData') || '{}');
     const editDTag = formData.edit_d_tag;
     window.location.href = editDTag ? '/ride?edit=' + encodeURIComponent(editDTag) : '/ride';
@@ -2155,14 +2198,102 @@ function cleanupLocationSelection() {
         map.removeLayer(locationSelectionMarker);
         locationSelectionMarker = null;
     }
-    
+
     const ui = document.querySelector('.location-selection-ui');
     if (ui) {
         ui.remove();
     }
-    
-    // Remove event listener
-    map.off('click');
-    
+
+    // Remove only our reposition handler — a bare map.off('click') would also
+    // detach handleMapClick, which matters when we stay on the map after cancel.
+    if (locationSelectionClickHandler) {
+        map.off('click', locationSelectionClickHandler);
+        locationSelectionClickHandler = null;
+    }
+
     locationSelectionType = null;
+    locationSelectionIsNewSpot = false;
+}
+
+// Wire up the "drop a pin to add a hitch site" gesture: touch long-press on
+// mobile, right-click on desktop. Called once from setupEventListeners.
+function setupAddSpotGesture() {
+    // Desktop: right-click drops a pin (and suppress the browser context menu).
+    map.on('contextmenu', function(e) {
+        if (e.originalEvent) e.originalEvent.preventDefault();
+        startAddSpotFromGesture(e.latlng, e.containerPoint);
+    });
+
+    // Touch: long-press drops a pin. Cancel on move (panning), lift, or a second
+    // finger (pinch-zoom) so only a deliberate stationary press triggers it.
+    const LONG_PRESS_MS = 500;
+    const MOVE_CANCEL_PX = 10;
+    const container = map.getContainer();
+    let timer = null, startX = 0, startY = 0;
+
+    const clearTimer = () => { if (timer) { clearTimeout(timer); timer = null; } };
+
+    container.addEventListener('touchstart', function(e) {
+        // Any non-single-touch (e.g. pinch) cancels a pending press.
+        if (e.touches.length !== 1) { clearTimer(); return; }
+        const t = e.touches[0];
+        startX = t.clientX;
+        startY = t.clientY;
+        clearTimer();
+        timer = setTimeout(function() {
+            timer = null;
+            const rect = container.getBoundingClientRect();
+            const cp = L.point(startX - rect.left, startY - rect.top);
+            startAddSpotFromGesture(map.containerPointToLatLng(cp), cp);
+        }, LONG_PRESS_MS);
+    }, { passive: true });
+
+    container.addEventListener('touchmove', function(e) {
+        if (!timer) return;
+        const t = e.touches[0];
+        if (Math.abs(t.clientX - startX) > MOVE_CANCEL_PX ||
+            Math.abs(t.clientY - startY) > MOVE_CANCEL_PX) {
+            clearTimer();
+        }
+    }, { passive: true });
+
+    container.addEventListener('touchend', clearTimer, { passive: true });
+    container.addEventListener('touchcancel', clearTimer, { passive: true });
+}
+
+// Return the nearest visible spot marker to a screen point within thresholdPx,
+// or null. Markers hidden inside a cluster are skipped so we only ever snap to a
+// pin the user can actually see.
+function findNearbySpotMarker(containerPoint, thresholdPx = 22) {
+    let best = null, bestDist = thresholdPx;
+    for (const marker of allMarkers) {
+        if (markerCluster && markerCluster.getVisibleParent(marker) !== marker) continue;
+        const d = map.latLngToContainerPoint(marker.getLatLng()).distanceTo(containerPoint);
+        if (d <= bestDist) {
+            bestDist = d;
+            best = marker;
+        }
+    }
+    return best;
+}
+
+// Begin adding a hitch site from a map gesture: seed a draggable pin (snapping
+// onto an existing spot when the press lands on one) and show the confirm panel.
+function startAddSpotFromGesture(latlng, containerPoint) {
+    // Ignore if a selection is already in progress.
+    if (locationSelectionMarker) return;
+
+    // Fresh ride — drop any leftover form state (edit mode, stale fields).
+    sessionStorage.removeItem('rideFormData');
+
+    // Snap onto a nearby existing spot so the new ride merges into it rather than
+    // creating a near-duplicate anchor (spot id derives from lat/lon at 5 decimals).
+    const snapped = containerPoint ? findNearbySpotMarker(containerPoint) : null;
+    const seedLatLng = snapped ? snapped.getLatLng() : latlng;
+
+    setupLocationSelection('select-pickup', null, {
+        initialLatLng: seedLatLng,
+        isNewSpot: true,
+        existingSpot: !!snapped,
+    });
 }

--- a/hitch/static/map.js
+++ b/hitch/static/map.js
@@ -2214,7 +2214,12 @@ function cleanupLocationSelection() {
 function setupAddSpotGesture() {
     // Desktop: right-click drops a pin (and suppress the browser context menu).
     map.on('contextmenu', function(e) {
-        if (e.originalEvent) e.originalEvent.preventDefault();
+        const oe = e.originalEvent;
+        // Ignore right-clicks landing on a Leaflet control (search box, the
+        // leaflet-bar buttons): the user is operating the control, not the map.
+        // Those controls only stopPropagation on click, not on contextmenu.
+        if (oe && oe.target.closest && oe.target.closest('.leaflet-control')) return;
+        if (oe) oe.preventDefault();
         startAddSpotFromGesture(e.latlng, e.containerPoint);
     });
 
@@ -2228,6 +2233,11 @@ function setupAddSpotGesture() {
     const clearTimer = () => { if (timer) { clearTimeout(timer); timer = null; } };
 
     container.addEventListener('touchstart', function(e) {
+        // Don't start a long-press over a Leaflet control (search box, the
+        // leaflet-bar buttons): the press is meant to operate the control, not
+        // drop a pin on top of it. Those controls only stopPropagation on click,
+        // so their native touchstart still bubbles up to this container listener.
+        if (e.target.closest && e.target.closest('.leaflet-control')) { clearTimer(); return; }
         // Any non-single-touch (e.g. pinch) cancels a pending press.
         if (e.touches.length !== 1) { clearTimer(); return; }
         const t = e.touches[0];

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -443,6 +443,68 @@ body.adding-spot .bottom-action-pane {
   display: none;
 }
 
+/* Hide the bottom action pane while dropping/confirming a pin so the compact
+   selection card can sit at the bottom without overlapping it. */
+body.selecting-location .bottom-action-pane {
+  display: none;
+}
+
+/* Compact confirm card for the long-press / "pick location on map" flow.
+   Pinned bottom-centre (Google-Maps style) so it never covers the top search bar. */
+.location-selection-ui {
+  position: fixed;
+  left: 50%;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  transform: translateX(-50%);
+  z-index: 2002;
+  width: max-content;
+  max-width: calc(100vw - 24px);
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  padding: 10px 14px;
+  text-align: center;
+}
+
+.location-selection-ui h4 {
+  margin: 0 0 2px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.location-selection-ui p {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.35;
+  color: #666;
+  max-width: 260px;
+}
+
+.location-selection-ui .lsel-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.location-selection-ui .lsel-actions button {
+  border: none;
+  border-radius: 7px;
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.location-selection-ui .lsel-confirm {
+  background: #1a73e8;
+  color: #fff;
+}
+
+.location-selection-ui .lsel-cancel {
+  background: #e9ecef;
+  color: #333;
+}
+
 body.adding-spot .leaflet-control-attribution {
   display: none;
 }

--- a/hitch/templates/map.html
+++ b/hitch/templates/map.html
@@ -141,7 +141,7 @@ var HIDE_ACCOUNT_BUTTON = {{ hide_account_button|tojson }};
     </div>
     <div id='spot-summary'></div>
     <div id="spot-rate-prompt">
-        <div class="rate-label">Rate your ride from this spot</div>
+        <div class="rate-label">Rate this spot</div>
         <div class="rate-stars" id="spot-rate-stars" role="radiogroup" aria-label="Rate this spot">
             <button type="button" class="rate-star" data-rate="1" aria-label="1 star">★</button>
             <button type="button" class="rate-star" data-rate="2" aria-label="2 stars">★</button>


### PR DESCRIPTION
## Summary

Adds a map gesture to drop a pin and add a hitch site, primarily for the mobile PWA:

- **Touch long-press** (mobile) or **right-click** (desktop) on the map drops a draggable pin and shows a compact confirm card.
- **Snaps onto a nearby existing spot** (within ~22px of a visible marker; clustered markers skipped) so the new ride merges into that spot instead of creating a near-duplicate — the panel then reads "Add a ride to this spot".
- **Confirm** opens the existing `/ride` form prefilled with the pin as pickup; **Cancel** stays on the map.

Reuses the existing location-selection machinery (`setupLocationSelection` / confirm / cancel) rather than adding a parallel flow.

## UX details
- Long-press is cancelled by panning, lift, or a second finger (pinch-zoom), so only a deliberate stationary press triggers it.
- The confirm panel is now a compact bottom-centre card (was a large top box that overlapped the search bar); the bottom action pane is hidden while selecting. This also improves the form's existing "pick location on map" flow.

## Notes
- Frontend only (`hitch/static/map.js`, `hitch/static/style.css`, `hitch/templates/map.html`). No backend changes; the service worker is network-first so the update propagates on next online load.
- Design spec included at `docs/superpowers/specs/2026-06-28-longpress-add-hitch-site-design.md`.
- Verified on a real device via an HTTPS tunnel against production spot data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)