### PR TITLE
ci: Node 24 runtime + stop network tests from gating CI

### DIFF
--- a/.github/workflows/ruff_linting.yml
+++ b/.github/workflows/ruff_linting.yml
@@ -4,9 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,14 +4,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      # Deselect network tests: they hit live third-party Nostr relays, so a
+      # relay outage would fail CI on unrelated code changes. Relay health is
+      # monitored separately, not gated on every push (marker defined in pytest.ini).
       - name: Run tests
-        run: python -m pytest tests/ -v
+        run: python -m pytest tests/ -v -m "not network"


### PR DESCRIPTION
## Why
Two CI issues surfaced on recent PRs:

1. **Node 20 deprecation** — `actions/checkout@v4` and `actions/setup-python@v5` run on the Node 20 runtime, which GitHub is sunsetting (forcing onto Node 24). This shows as deprecation warnings on every run.
2. **Flaky external test gating PRs** — `test_nostr_relays_have_at_least_one_ride_event` opens live WebSocket connections to third-party Nostr relays. When a relay is down/empty (the nomadwiki relay is under active debugging per CLAUDE.md), CI fails on **unrelated** code changes.

## Changes
- Bump `actions/checkout` v4 → **v5** and `actions/setup-python` v5 → **v6** in `tests.yml` and `ruff_linting.yml` (both run on Node 24).
- Run `pytest tests/ -v -m "not network"` so the relay test no longer gates CI. The `network` marker already exists in `pytest.ini` for exactly this purpose. Only that one test is network-marked; all app tests and the `test_at_least_one_spot_on_map` integration test still run.

## Follow-up (not in this PR)
Optionally add a scheduled workflow that runs `-m network` daily as a relay-health monitor, so we still get a signal without blocking pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)