### PR TITLE
fix(map): close X on Hitchwiki country/event panes actually closes

### DIFF
--- a/hitch/static/map.js
+++ b/hitch/static/map.js
@@ -2137,6 +2137,15 @@ function navigateHome() {
     window.RoutingUI.showAgain();
     return;
   }
+  // Panes opened via a navigation hash (#country/<name>, #event, #menu, …) leave that
+  // hash in the URL; clearSpotUrl only resets /spot/ paths, so navigate() below would
+  // otherwise re-read the hash and reopen the pane — the close X would appear to
+  // "reload" the wiki sheet rather than close it. Drop it, keeping a #map= viewport.
+  if (window.location.hash && !parseMapHash(window.location.hash)) {
+    const url = new URL(window.location.href);
+    url.hash = "";
+    window.history.pushState({}, "", url);
+  }
   navigate(); // clears rest
 }
 


### PR DESCRIPTION
## Problem
Closing a **hash-based pane** — the Hitchwiki **country** info sheet (`#country/<name>`), the **event** sheet (`#event`), and the **menu** (`#menu`) — doesn't work: tapping the × **reopens the sheet and re-fetches its Hitchwiki content**, so it reads as a refresh/reload rather than a close.

## Root cause
The close × calls `navigateHome()` → `clearSpotUrl()` → `navigate()`. But `clearSpotUrl()` only resets `/spot/<lat>_<lon>` paths and legacy `?lat=&lon=` params — it **early-returns for panes opened via a navigation hash** and never clears the hash. So the `#country/…` (etc.) hash survives, and `navigate()` re-reads it and re-runs `openCountrySheet()`.

Introduced by the OSM-style URL rework; it affects the live site.

## Fix
`navigateHome()` now drops a leftover navigation hash (while preserving a `#map=` viewport hash) before calling `navigate()`, so the pane actually closes.

```js
if (window.location.hash && !parseMapHash(window.location.hash)) {
  const url = new URL(window.location.href);
  url.hash = "";
  window.history.pushState({}, "", url);
}
```

One-file, +9 lines. Also fixed independently on `feature/driver-demographic-logging` (PR #102); this standalone PR lets `main` get it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)