### PR TITLE
Cache-Control: immutable busted assets, SWR for generated data, and no session cookie on cacheable responses

### DIFF
--- a/docs/superpowers/plans/2026-07-10-cache-control.md
+++ b/docs/superpowers/plans/2026-07-10-cache-control.md
@@ -1,0 +1,156 @@
+# Cache-Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve `/static/*` with long-lived immutable caching and `dist/*` generated data with short `max-age` + `stale-while-revalidate`, and stop `Vary: Cookie` from fragmenting those public responses.
+
+**Architecture:** A single `after_request` hook registered in `register_routes(app)` sets `Cache-Control`/`Vary` based on the matched endpoint (`static` vs `catch_all`), overriding the `no-cache` + `Vary: Cookie` that Werkzeug (no `max_age`) and the session layer inject. HTML routes, `sw.js`, and route JSON endpoints are left untouched.
+
+**Tech Stack:** Flask (`hitch/__init__.py`), pytest with the existing `client` fixture (`tests/conftest.py`).
+
+**Design doc:** `docs/superpowers/specs/2026-07-10-cache-control-design.md`
+
+## Global Constraints
+
+- Static assets (`/static/*`, endpoint `static`): `Cache-Control: public, max-age=31536000, immutable` and `Vary: Accept-Encoding`.
+- Generated data (`dist/*`, endpoint `catch_all`): `Cache-Control: public, max-age=300, stale-while-revalidate=600` and `Vary: Accept-Encoding`.
+- These two are the ONLY endpoints the hook touches. HTML (`/`, `/spot/…`, `/copyright`), `sw.js`, `favicon.ico`, `manifest.json`, and route JSON endpoints must keep their existing headers (must NOT get `max-age=31536000`).
+- `Vary` on the two cached endpoints must NOT contain `Cookie`.
+- The `after_request` hook must win over any `no-cache`/`Vary: Cookie` the stack injects; the pytest below is the guard (it exercises the full WSGI stack).
+
+---
+
+### Task 1: `after_request` cache-control hook + header tests
+
+**Files:**
+- Modify: `hitch/__init__.py` (inside `register_routes`, after the `sw` route ~line 250-255; `request` and `baseDir` are already in scope/module)
+- Test: `tests/test_cache_headers.py` (create)
+
+**Interfaces:**
+- Consumes: Flask `request.endpoint`, the existing `static` and `catch_all` routes, module-level `baseDir` (`hitch/__init__.py:23`).
+- Produces: `set_public_cache_headers(response)` registered via `@app.after_request` — sets `Cache-Control`/`Vary` on `static` and `catch_all` responses only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_cache_headers.py`:
+
+```python
+import os
+
+from hitch import baseDir
+
+
+def test_static_assets_are_immutably_cached(client):
+    # /static/* URLs are cache-busted with ?v=<mtime> (asset_url), so the body at a
+    # given URL never changes and can be cached hard.
+    resp = client.get("/static/map.js")
+    assert resp.status_code == 200
+    cc = resp.headers.get("Cache-Control", "")
+    assert "max-age=31536000" in cc
+    assert "immutable" in cc
+    assert "Cookie" not in resp.headers.get("Vary", "")
+
+
+def test_dist_data_is_swr_cached(client):
+    # Write a throwaway file under dist/ so the test never depends on generated data.
+    dist_dir = os.path.join(baseDir, "dist")
+    os.makedirs(dist_dir, exist_ok=True)
+    marker = os.path.join(dist_dir, "_cache_test.json")
+    with open(marker, "w") as fh:
+        fh.write('{"ok": true}')
+    try:
+        resp = client.get("/_cache_test.json")
+        assert resp.status_code == 200
+        cc = resp.headers.get("Cache-Control", "")
+        assert "max-age=300" in cc
+        assert "stale-while-revalidate=600" in cc
+        assert "Cookie" not in resp.headers.get("Vary", "")
+    finally:
+        os.remove(marker)
+
+
+def test_html_is_not_long_cached(client):
+    # HTML must stay revalidate so new ?v= asset links propagate on the next load.
+    resp = client.get("/copyright")
+    assert resp.status_code == 200
+    assert "max-age=31536000" not in resp.headers.get("Cache-Control", "")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_cache_headers.py -v`
+Expected: `test_static_assets_are_immutably_cached` and `test_dist_data_is_swr_cached` FAIL (current headers are `no-cache`, no `max-age`/`immutable`/`stale-while-revalidate`). `test_html_is_not_long_cached` may already pass — that's fine, it's a regression guard.
+
+- [ ] **Step 3: Implement the hook**
+
+In `hitch/__init__.py`, inside `register_routes(app)`, after the `sw()` route, add:
+
+```python
+    # Cache policy for public, versioned/generated files, in one place so it OVERRIDES
+    # the no-cache + Vary: Cookie that Werkzeug (send_from_directory with no max_age) and
+    # the session layer inject — both defeat caching of files that are safe to cache.
+    # HTML, sw.js, and route endpoints are intentionally left untouched so new ?v= asset
+    # links and service-worker updates keep propagating on the next load.
+    @app.after_request
+    def set_public_cache_headers(response):
+        endpoint = request.endpoint
+        if endpoint == "static":
+            # ?v=<mtime> busting (asset_url) makes each URL's body immutable.
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            response.headers["Vary"] = "Accept-Encoding"
+        elif endpoint == "catch_all":
+            # dist/* regenerates every ~10 min and is already ~40 min stale by design, so
+            # a 5-min cache + stale-while-revalidate is invisible and skips the reload
+            # revalidation round-trip; ETag/Last-Modified stay for the >15-min case. These
+            # files vary only by gzip vs plain, never by cookie — drop Vary: Cookie.
+            response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=600"
+            response.headers["Vary"] = "Accept-Encoding"
+        return response
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_cache_headers.py -v`
+Expected: all three PASS. If `test_dist_data_is_swr_cached`/`test_static_...` still show `Cookie` in `Vary`, the session layer is re-adding it after `after_request`; escalate — the hook may need to run last or the header force-set differently (see design doc "Risk to verify empirically").
+
+- [ ] **Step 5: Full regression + lint**
+
+Run: `.venv/bin/python -m pytest tests/ -q --deselect tests/test_integration.py::test_nostr_relays_have_at_least_one_ride_event`
+Expected: all pass (previous baseline: 34 passed).
+Run: `.venv/bin/ruff check hitch/__init__.py tests/test_cache_headers.py`
+Expected: clean.
+
+- [ ] **Step 6: Live verification against a running server**
+
+Confirms the header values survive the real stack (test client and prod can differ in session handling) and that the `.gz` branch is unaffected.
+
+Start (if not already running): `FLASK_APP=hitch .venv/bin/flask run --port 5001 --debug` (background).
+
+Run and eyeball:
+```
+# static: immutable, no Cookie
+curl -s -D - -o /dev/null http://localhost:5001/static/map.js | grep -iE "cache-control|vary"
+# dist plain: SWR, no Cookie
+curl -s -D - -o /dev/null http://localhost:5001/spots.json | grep -iE "cache-control|vary"
+# dist gz branch: SWR + Content-Encoding: gzip + Vary: Accept-Encoding preserved
+curl -s -D - -o /dev/null --compressed http://localhost:5001/spots.json | grep -iE "cache-control|vary|content-encoding"
+# HTML: NOT long-cached
+curl -s -D - -o /dev/null http://localhost:5001/ | grep -iE "cache-control"
+```
+Expected: static → `max-age=31536000, immutable`, `Vary: Accept-Encoding`. dist (both) → `max-age=300, stale-while-revalidate=600`, `Vary: Accept-Encoding`; gz request also keeps `Content-Encoding: gzip`. HTML → no `max-age=31536000`.
+(If `spots.json` isn't present in dev, use any file under `dist/`, or the `_cache_test.json` approach from the test.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hitch/__init__.py tests/test_cache_headers.py
+git commit -m "feat(cache): immutable /static, SWR dist data, drop Vary: Cookie"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 static immutable → Step 3 `static` branch + test 1. §2 dist SWR → Step 3 `catch_all` branch + test 2 (both branches covered because the hook runs on every response, incl. the gz early-return; verified in Step 6). §3 untouched HTML → test 3 guard; `sw.js`/favicon/manifest/route JSON are other endpoints the hook's `if/elif` never matches. `Vary: Cookie` removal → asserted in tests 1 & 2 and Step 6. Empirical risk → Step 4 escalation note + Step 6 live curl.
+- **Placeholders:** none — all code and commands are concrete.
+- **Type/name consistency:** `set_public_cache_headers`, `request.endpoint` values `"static"`/`"catch_all"`, `baseDir`, and header strings match the design doc's Global Constraints verbatim.

--- a/docs/superpowers/specs/2026-07-10-cache-control-design.md
+++ b/docs/superpowers/specs/2026-07-10-cache-control-design.md
@@ -50,19 +50,29 @@ rendered HTML, or caching authenticated / route-driven JSON endpoints.
 
 ### 1. Static assets — `/static/*`
 
-Served by Flask's built-in static route; URLs already include `?v=<mtime>`
-(changes on every file edit), so the body at a given URL is immutable.
+Served by Flask's built-in static route. **Only URLs carrying the `?v=<mtime>`
+cache-buster get the immutable treatment**, because only `map.html` uses
+`asset_url()`. Bare `/static/…` URLs are common — `style.css` from
+`ride_detail.html` / `report_ride.html` / `leaderboard.html` / `recent.html`,
+the marker icons and `countries.geojson` fetched from JS, `sw.js`'s icon, and
+the `manifest.json` icons. Their bodies *do* change across deploys under a
+stable URL, so pinning them for a year would strand clients on old assets.
 
 ```
+# with ?v=<mtime>
 Cache-Control: public, max-age=31536000, immutable
+Vary: Accept-Encoding
+
+# without ?v=
+Cache-Control: public, max-age=300
 Vary: Accept-Encoding
 ```
 
-- 1 year + `immutable` — returning visitors never re-request `map.js`,
-  `style.css`, or marker images until their URL changes.
-- Safe because a content change changes the `?v=` query, which is a new cache
-  key. The rendered HTML that references these URLs is **not** long-cached (see
-  §3), so new `?v=` links propagate on the next page load.
+- Busted URLs: 1 year + `immutable` — returning visitors never re-request them
+  until the URL changes. Safe because a content change changes the `?v=` query,
+  which is a new cache key, and the rendered HTML that references these URLs is
+  **not** long-cached (see §3), so new `?v=` links propagate on the next load.
+- Bare URLs: cache briefly, then revalidate (`ETag` makes the recheck a 304).
 
 ### 2. Generated data — `dist/*` via `catch_all`
 
@@ -119,15 +129,37 @@ Rationale for `after_request` over per-call `max_age=`: it is one central place,
 it can *remove* the `no-cache`/`Vary: Cookie` that other layers inject, and it
 keeps `catch_all`'s existing gz logic untouched.
 
-### Risk to verify empirically
+### Risk to verify empirically — CONFIRMED, and worse than expected
 
-`no-cache` + `Vary: Cookie` may be injected during response finalization (the
-session/login layer), potentially *after* `after_request` runs. These public
-paths never touch the session, so the values should stick — but this must be
-**confirmed with live `curl`** against the running server after the change
-(assert the final `Cache-Control`/`Vary` on `/static/<asset>` and a `dist/`
-file). If a later layer re-adds `Vary: Cookie`, the hook must force-set the
-header last (or ensure these responses are session-neutral).
+The anticipated risk materialized, and investigating it surfaced a security
+issue. `Flask.process_response` runs every `@app.after_request` hook and *then*
+calls `session_interface.save_session()` as a hard-coded final step. No
+`after_request` hook can out-run it. And `save_session()`:
+
+1. appends `Vary: Cookie` whenever `session.accessed` is true — which
+   flask_security/flask_principal cause on **every** request (their identity
+   loader checks login state in `before_request`), including `/static/*` and
+   `dist/*`; and
+2. **emits `Set-Cookie`** whenever the session is modified, and on *every*
+   request for a permanent session (`SESSION_REFRESH_EACH_REQUEST` defaults to
+   `True`).
+
+(2) is the dangerous one: a `Set-Cookie` riding on a response we advertise as
+`public, max-age=…` means a shared cache or CDN could store one visitor's
+session cookie and serve it to another. Verified empirically — with a permanent
+session, `/static/map.js` returned `Cache-Control: public, max-age=31536000`
+*and* a live `session=…` `Set-Cookie`.
+
+**Resolution:** a `SecureCookieSessionInterface` subclass
+(`_CacheAwareSessionInterface`) overrides `save_session` to **skip it entirely**
+for the `static` and `catch_all` endpoints. `save_session` runs inside the
+request context, so `request.endpoint` is available there. Skipping prevents
+both the `Set-Cookie` and the `Vary: Cookie`, and is safe: those endpoints serve
+static files and pre-generated data, never mutate the session, and any session
+change is persisted by the next non-cacheable request.
+
+This is guarded by `test_no_set_cookie_on_publicly_cacheable_responses`, which
+was confirmed to fail against the pre-fix code.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-10-cache-control-design.md
+++ b/docs/superpowers/specs/2026-07-10-cache-control-design.md
@@ -1,0 +1,152 @@
+# Cache-Control for static assets and generated data — Design
+
+**Date:** 2026-07-10
+**Branch:** `feature/cache-control` (from `main` @ `5e8caf8`)
+**Status:** Approved, ready for implementation plan
+
+## Problem
+
+Every file the app serves comes back with `Cache-Control: no-cache` and
+`Vary: Cookie`. Both actively defeat caches that would otherwise work:
+
+- **`no-cache`** forces the browser to revalidate on *every* request. Werkzeug
+  emits it because `catch_all` and Flask's static route call
+  `send_from_directory` with no `max_age` (and `SEND_FILE_MAX_AGE_DEFAULT` is
+  unset). `no-cache` still *stores* the body, but the browser must make a
+  conditional round-trip before reusing it — and whenever the file changed, it
+  re-downloads the whole thing.
+- **`Vary: Cookie`** (injected by the session/login layer) fragments the cache
+  per distinct `Cookie` header, so a returning visitor whose session cookie
+  changed re-fetches from scratch and no shared/CDN cache can be reused.
+
+Measured impact (live prod headers):
+
+| File | Size | Current headers |
+|---|---|---|
+| `rides_index.json` | **26.5 MB** | `no-cache`, `Vary: Cookie` |
+| `spots.json` | **4.2 MB** | `no-cache`, `Vary: Cookie` |
+| `static/map.js` | 141 KB | `no-cache`, `Vary: Cookie` |
+
+`rides_index.json` and `spots.json` regenerate every ~10 min (`show.py` cron),
+so a returning visitor frequently pays a full multi-MB re-download. The static
+assets already carry a `?v=<mtime>` cache-buster from `asset_url()` (`hitch/__init__.py`),
+yet `no-cache` means that cache-busting buys nothing — a stable URL still
+re-downloads.
+
+Data is already up to ~40 min stale by design (`fetch_nostr` every 30 min +
+`show` every 10 min), so a few extra minutes of client-side staleness costs
+nothing perceptible.
+
+## Goals
+
+1. `/static/*` (cache-busted URLs) → long-lived immutable caching.
+2. Big `dist/*` generated data → short `max-age` + `stale-while-revalidate`.
+3. Stop `Vary: Cookie` from fragmenting these public responses.
+
+Non-goals: changing the service worker (`sw.js` stays network-first), caching
+rendered HTML, or caching authenticated / route-driven JSON endpoints.
+
+## Design
+
+### 1. Static assets — `/static/*`
+
+Served by Flask's built-in static route; URLs already include `?v=<mtime>`
+(changes on every file edit), so the body at a given URL is immutable.
+
+```
+Cache-Control: public, max-age=31536000, immutable
+Vary: Accept-Encoding
+```
+
+- 1 year + `immutable` — returning visitors never re-request `map.js`,
+  `style.css`, or marker images until their URL changes.
+- Safe because a content change changes the `?v=` query, which is a new cache
+  key. The rendered HTML that references these URLs is **not** long-cached (see
+  §3), so new `?v=` links propagate on the next page load.
+
+### 2. Generated data — `dist/*` via `catch_all`
+
+```
+Cache-Control: public, max-age=300, stale-while-revalidate=600
+Vary: Accept-Encoding
+```
+
+- `0–5 min`: served from cache with no network round-trip.
+- `5–15 min`: served stale instantly while the browser refreshes in the
+  background (`stale-while-revalidate`).
+- `>15 min`: normal revalidation — `ETag`/`Last-Modified` are preserved, so an
+  unchanged file returns `304 Not Modified` (tiny), and the full body downloads
+  only when the file actually changed.
+- Worst-case added staleness: ~5 min on top of the existing ~40 min pipeline
+  lag — negligible.
+
+Applied **uniformly to all `dist/*` files** for simplicity. Files with a slower
+regeneration cadence (`events.json` daily, `country_ratings.json` monthly) just
+refresh a little more often than strictly necessary — harmless.
+
+Applied on **both** branches of `catch_all`:
+- the precompressed `.gz` sidecar branch (which already sets
+  `Vary: Accept-Encoding` and `Content-Encoding: gzip`), and
+- the plain `send_from_directory` branch.
+
+`Vary` is set to `Accept-Encoding` (correct — the response genuinely varies by
+gzip vs plain), replacing the injected `Vary: Cookie`.
+
+### 3. Deliberately untouched
+
+- **Rendered HTML** (`/`, `/spot/…`, `/copyright`): stays revalidate/`no-cache`
+  so a new deploy's `?v=` asset links are picked up immediately. This is the
+  invariant that makes §1's immutable caching safe.
+- **`sw.js`**: stays `no-cache`. The service worker is the update mechanism and
+  must never be long-cached, or clients get stuck on an old worker.
+- **Route JSON endpoints** (e.g. `/driver_info_choices.json`): left as-is —
+  small, and not part of the `dist/` static-file path.
+
+## Implementation approach
+
+A single `after_request` hook in `register_routes` (or `create_app`), keyed on
+`request.path`:
+
+- `request.path.startswith("/static/")` → set the §1 immutable header.
+- the `dist/*` responses from `catch_all` → set the §2 SWR header. Identify
+  these by the request being handled by `catch_all` (e.g. endpoint name
+  `catch_all`) rather than by guessing from the path, so route endpoints and
+  HTML are never caught.
+- In both cases, replace `Vary: Cookie` with `Vary: Accept-Encoding` and drop
+  the `no-cache` that Werkzeug added.
+
+Rationale for `after_request` over per-call `max_age=`: it is one central place,
+it can *remove* the `no-cache`/`Vary: Cookie` that other layers inject, and it
+keeps `catch_all`'s existing gz logic untouched.
+
+### Risk to verify empirically
+
+`no-cache` + `Vary: Cookie` may be injected during response finalization (the
+session/login layer), potentially *after* `after_request` runs. These public
+paths never touch the session, so the values should stick — but this must be
+**confirmed with live `curl`** against the running server after the change
+(assert the final `Cache-Control`/`Vary` on `/static/<asset>` and a `dist/`
+file). If a later layer re-adds `Vary: Cookie`, the hook must force-set the
+header last (or ensure these responses are session-neutral).
+
+## Testing
+
+- **pytest** (`tests/`): using the Flask test client, request a `/static/`
+  asset and a `dist/` file (create a throwaway file under `dist/` in the test
+  if none is guaranteed present), and assert:
+  - `/static/*` → `Cache-Control` contains `max-age=31536000` and `immutable`;
+    `Vary` does not contain `Cookie`.
+  - `dist/*` → `Cache-Control` contains `max-age=300` and
+    `stale-while-revalidate=600`; `Vary` does not contain `Cookie`.
+  - a rendered HTML route (`/copyright`) is **not** long-cached (guards §3).
+- **Live curl** verification against `flask run` for the headers above,
+  including a gzip request (`--compressed`) to confirm the `.gz` branch keeps
+  `Content-Encoding: gzip` + `Vary: Accept-Encoding` alongside the new
+  `Cache-Control`.
+
+## Rollout notes
+
+- No data-model or generation changes; headers only. Reversible by removing the
+  hook.
+- First deploy: clients holding the old `no-cache` copies simply pick up the new
+  headers on their next fetch; nothing to invalidate.

--- a/hitch/__init__.py
+++ b/hitch/__init__.py
@@ -9,6 +9,7 @@ import time as time_module
 
 import click
 from flask import Flask, render_template, request, send_from_directory
+from flask.sessions import SecureCookieSessionInterface
 from flask_security import SQLAlchemyUserDatastore
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.utils import safe_join
@@ -28,6 +29,30 @@ if ENVIRONMENT not in ["prod", "dev"]:
     sys.exit(1)
 
 
+class _CacheAwareSessionInterface(SecureCookieSessionInterface):
+    """Flask.process_response runs every @app.after_request hook and only *then*
+    calls session_interface.save_session() unconditionally (see flask/app.py:
+    process_response loops over after_request_funcs first, then calls
+    save_session as the final step) -- and save_session() does
+    response.vary.add("Cookie") whenever session.accessed is True, which
+    flask_security/flask_principal cause on every request (even /static and
+    dist/* ones, since the identity loader checks login state before_request).
+    No after_request hook can out-run that append. But save_session() runs
+    inside the request context, so request.endpoint IS available here --
+    this is the one place that runs after the re-add and can undo it, scoped
+    to exactly the two endpoints set_public_cache_headers marked cacheable.
+    """
+
+    def save_session(self, app, session, response):
+        super().save_session(app, session, response)
+        if request.endpoint in ("static", "catch_all"):
+            # Must be lowercase: werkzeug's HeaderSet.remove() compares the
+            # lowercased stored token against the *unlowered* argument, so
+            # discard("Cookie") silently no-ops -- discard("cookie") is the
+            # only case that actually matches and removes it.
+            response.vary.discard("cookie")
+
+
 def create_app(config_name=None):
     if config_name is None:
         config_name = os.getenv("FLASK_CONFIG", "development")
@@ -37,6 +62,9 @@ def create_app(config_name=None):
     # needed fo r correct OAuth callback URLs and to avoid mixed content issues when behind a reverse proxy
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
     app.config.from_object(config[config_name])
+    # See _CacheAwareSessionInterface for why Vary: Cookie needs stripping here,
+    # not in an after_request hook.
+    app.session_interface = _CacheAwareSessionInterface()
 
     register_extensions(app)
     register_blueprints(app)
@@ -253,3 +281,24 @@ def register_routes(app):
             os.path.join(app.root_path, "static"),
             "sw.js",
         )
+
+    # Cache policy for public, versioned/generated files, in one place so it OVERRIDES
+    # the no-cache + Vary: Cookie that Werkzeug (send_from_directory with no max_age) and
+    # the session layer inject — both defeat caching of files that are safe to cache.
+    # HTML, sw.js, and route endpoints are intentionally left untouched so new ?v= asset
+    # links and service-worker updates keep propagating on the next load.
+    @app.after_request
+    def set_public_cache_headers(response):
+        endpoint = request.endpoint
+        if endpoint == "static":
+            # ?v=<mtime> busting (asset_url) makes each URL's body immutable.
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            response.headers["Vary"] = "Accept-Encoding"
+        elif endpoint == "catch_all":
+            # dist/* regenerates every ~10 min and is already ~40 min stale by design, so
+            # a 5-min cache + stale-while-revalidate is invisible and skips the reload
+            # revalidation round-trip; ETag/Last-Modified stay for the >15-min case. These
+            # files vary only by gzip vs plain, never by cookie — drop Vary: Cookie.
+            response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=600"
+            response.headers["Vary"] = "Accept-Encoding"
+        return response

--- a/hitch/__init__.py
+++ b/hitch/__init__.py
@@ -8,7 +8,7 @@ import sys
 import time as time_module
 
 import click
-from flask import Flask, render_template, request, send_from_directory
+from flask import Flask, has_request_context, render_template, request, send_from_directory
 from flask.sessions import SecureCookieSessionInterface
 from flask_security import SQLAlchemyUserDatastore
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -29,28 +29,40 @@ if ENVIRONMENT not in ["prod", "dev"]:
     sys.exit(1)
 
 
+# The endpoints set_public_cache_headers marks publicly cacheable. Their responses are
+# identical for every visitor and must never carry per-user state.
+_PUBLIC_CACHE_ENDPOINTS = ("static", "catch_all")
+
+
 class _CacheAwareSessionInterface(SecureCookieSessionInterface):
-    """Flask.process_response runs every @app.after_request hook and only *then*
-    calls session_interface.save_session() unconditionally (see flask/app.py:
-    process_response loops over after_request_funcs first, then calls
-    save_session as the final step) -- and save_session() does
-    response.vary.add("Cookie") whenever session.accessed is True, which
-    flask_security/flask_principal cause on every request (even /static and
-    dist/* ones, since the identity loader checks login state before_request).
-    No after_request hook can out-run that append. But save_session() runs
-    inside the request context, so request.endpoint IS available here --
-    this is the one place that runs after the re-add and can undo it, scoped
-    to exactly the two endpoints set_public_cache_headers marked cacheable.
+    """Keeps session state off responses we advertise as publicly cacheable.
+
+    Flask.process_response runs every @app.after_request hook and only *then* calls
+    session_interface.save_session() (see flask/app.py: it loops over
+    after_request_funcs first, then calls save_session as the final step). So no
+    after_request hook can undo what save_session does -- but save_session runs inside
+    the request context, so request.endpoint is available here.
+
+    save_session does two things we must prevent on a `public, max-age=...` response:
+
+    1. It emits Set-Cookie whenever the session is modified, or on every request for a
+       permanent session (SESSION_REFRESH_EACH_REQUEST defaults to True). A shared cache
+       or CDN honouring `public` could store that response *with* the Set-Cookie and hand
+       one visitor's session to another. This is the reason we skip, not merely reorder.
+    2. It appends Vary: Cookie whenever session.accessed is True -- which
+       flask_security/flask_principal cause on EVERY request, including /static and
+       dist/* ones, since the identity loader checks login state in before_request. That
+       Vary fragments the cache per cookie and defeats the caching entirely.
+
+    Skipping save_session for these endpoints avoids both. It is safe: they serve static
+    files and pre-generated data, never mutate the session, and a session created or
+    cleared elsewhere is persisted by the very next non-cacheable request.
     """
 
     def save_session(self, app, session, response):
+        if has_request_context() and request.endpoint in _PUBLIC_CACHE_ENDPOINTS:
+            return
         super().save_session(app, session, response)
-        if request.endpoint in ("static", "catch_all"):
-            # Must be lowercase: werkzeug's HeaderSet.remove() compares the
-            # lowercased stored token against the *unlowered* argument, so
-            # discard("Cookie") silently no-ops -- discard("cookie") is the
-            # only case that actually matches and removes it.
-            response.vary.discard("cookie")
 
 
 def create_app(config_name=None):
@@ -291,8 +303,18 @@ def register_routes(app):
     def set_public_cache_headers(response):
         endpoint = request.endpoint
         if endpoint == "static":
-            # ?v=<mtime> busting (asset_url) makes each URL's body immutable.
-            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            if request.args.get("v"):
+                # ?v=<mtime> busting (asset_url) means a content change changes the URL,
+                # so the body at THIS url can never change -> cache it for a year.
+                response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            else:
+                # Plenty of /static/ URLs carry no ?v=: only map.html uses asset_url, so
+                # style.css from ride_detail/report_ride/leaderboard/recent, the marker
+                # icons and countries.geojson fetched from JS, sw.js's icon and the
+                # manifest icons all arrive bare. Their bodies DO change across deploys
+                # under a stable URL, so `immutable` would pin them for a year. Cache
+                # briefly, then revalidate (ETag turns the recheck into a 304).
+                response.headers["Cache-Control"] = "public, max-age=300"
             response.headers["Vary"] = "Accept-Encoding"
         elif endpoint == "catch_all":
             # dist/* regenerates every ~10 min and is already ~40 min stale by design, so

--- a/tests/test_cache_headers.py
+++ b/tests/test_cache_headers.py
@@ -1,0 +1,46 @@
+import os
+
+from hitch import baseDir
+
+
+def test_static_assets_are_immutably_cached(client):
+    # /static/* URLs are cache-busted with ?v=<mtime> (asset_url), so the body at a
+    # given URL never changes and can be cached hard.
+    resp = client.get("/static/map.js")
+    assert resp.status_code == 200
+    cc = resp.headers.get("Cache-Control", "")
+    assert "max-age=31536000" in cc
+    assert "immutable" in cc
+    assert "Cookie" not in resp.headers.get("Vary", "")
+
+
+def test_dist_data_is_swr_cached(client):
+    # Write a throwaway file under dist/ so the test never depends on generated data.
+    dist_dir = os.path.join(baseDir, "dist")
+    os.makedirs(dist_dir, exist_ok=True)
+    marker = os.path.join(dist_dir, "_cache_test.json")
+    with open(marker, "w") as fh:
+        fh.write('{"ok": true}')
+    try:
+        resp = client.get("/_cache_test.json")
+        assert resp.status_code == 200
+        cc = resp.headers.get("Cache-Control", "")
+        assert "max-age=300" in cc
+        assert "stale-while-revalidate=600" in cc
+        assert "Cookie" not in resp.headers.get("Vary", "")
+    finally:
+        os.remove(marker)
+
+
+def test_html_is_not_long_cached(client):
+    # HTML must stay revalidate so new ?v= asset links propagate on the next load.
+    resp = client.get("/copyright")
+    assert resp.status_code == 200
+    assert "max-age=31536000" not in resp.headers.get("Cache-Control", "")
+
+
+def test_vary_cookie_preserved_on_non_cacheable_routes(client):
+    # Guards against the cache-aware session interface stripping "Cookie" from
+    # Vary globally instead of only on the two cacheable endpoints.
+    resp = client.get("/copyright")
+    assert "Cookie" in resp.headers.get("Vary", "")

--- a/tests/test_cache_headers.py
+++ b/tests/test_cache_headers.py
@@ -3,14 +3,26 @@ import os
 from hitch import baseDir
 
 
-def test_static_assets_are_immutably_cached(client):
-    # /static/* URLs are cache-busted with ?v=<mtime> (asset_url), so the body at a
-    # given URL never changes and can be cached hard.
-    resp = client.get("/static/map.js")
+def test_busted_static_assets_are_immutably_cached(client):
+    # A ?v=<mtime> URL (asset_url) can never change body under the same URL.
+    resp = client.get("/static/map.js?v=123")
     assert resp.status_code == 200
     cc = resp.headers.get("Cache-Control", "")
     assert "max-age=31536000" in cc
     assert "immutable" in cc
+    assert "Cookie" not in resp.headers.get("Vary", "")
+
+
+def test_unbusted_static_assets_are_not_pinned(client):
+    # Only map.html uses asset_url; style.css (ride_detail/report_ride/...), the marker
+    # icons and countries.geojson (fetched from JS), sw.js's icon and the manifest icons
+    # all arrive with no ?v=. Their bodies change across deploys under a stable URL, so
+    # they must NOT be pinned for a year.
+    resp = client.get("/static/map.js")
+    assert resp.status_code == 200
+    cc = resp.headers.get("Cache-Control", "")
+    assert "max-age=31536000" not in cc
+    assert "immutable" not in cc
     assert "Cookie" not in resp.headers.get("Vary", "")
 
 
@@ -44,3 +56,41 @@ def test_vary_cookie_preserved_on_non_cacheable_routes(client):
     # Vary globally instead of only on the two cacheable endpoints.
     resp = client.get("/copyright")
     assert "Cookie" in resp.headers.get("Vary", "")
+
+
+def test_no_set_cookie_on_publicly_cacheable_responses(app):
+    """A `public, max-age=...` response must never carry Set-Cookie.
+
+    A shared cache/CDN could store the response together with the session cookie and
+    serve one visitor's session to another. save_session emits Set-Cookie whenever the
+    session is modified, and on EVERY request for a permanent session
+    (SESSION_REFRESH_EACH_REQUEST defaults to True) — so this needs a live session.
+    """
+    dist_dir = os.path.join(baseDir, "dist")
+    os.makedirs(dist_dir, exist_ok=True)
+    marker = os.path.join(dist_dir, "_cookie_test.json")
+    with open(marker, "w") as fh:
+        fh.write('{"ok": true}')
+
+    previous_refresh = app.config.get("SESSION_REFRESH_EACH_REQUEST")
+    app.config["SESSION_REFRESH_EACH_REQUEST"] = True
+    try:
+        with app.test_client() as client:
+            # Plant a permanent session so save_session would re-emit the cookie on
+            # every subsequent request.
+            with client.session_transaction() as sess:
+                sess["planted"] = "1"
+                sess.permanent = True
+
+            # Sanity: a non-cacheable route DOES still set the cookie, otherwise this
+            # test would pass vacuously (e.g. if sessions were disabled entirely).
+            assert client.get("/copyright").headers.getlist("Set-Cookie")
+
+            for path in ("/static/map.js", "/static/map.js?v=1", "/_cookie_test.json"):
+                resp = client.get(path)
+                assert resp.status_code == 200
+                assert "public" in resp.headers.get("Cache-Control", "")
+                assert not resp.headers.getlist("Set-Cookie"), f"Set-Cookie leaked on {path}"
+    finally:
+        app.config["SESSION_REFRESH_EACH_REQUEST"] = previous_refresh
+        os.remove(marker)


### PR DESCRIPTION
## Why

Every file the app served came back `Cache-Control: no-cache` + `Vary: Cookie`. Both actively defeat caching that would otherwise work:

- **`no-cache`** forces a revalidation round-trip on *every* request (Werkzeug's default when `send_from_directory` gets no `max_age`).
- **`Vary: Cookie`** (added by the session layer) fragments the cache per-cookie, so a returning visitor whose session cookie changed re-fetches from scratch and no shared cache can be reused.

Measured on prod:

| File | Size | Before |
|---|---|---|
| `rides_index.json` | **26.5 MB** | `no-cache`, `Vary: Cookie` |
| `spots.json` | **4.2 MB** | `no-cache`, `Vary: Cookie` |
| `static/map.js` | 141 KB | `no-cache`, `Vary: Cookie` |

`spots.json` / `rides_index.json` regenerate every ~10 min, so returning visitors frequently paid a full multi-MB re-download. Static assets already carried a `?v=<mtime>` buster, yet `no-cache` meant that bought nothing.

## What changed

An `after_request` hook sets the cache policy, keyed on the matched endpoint:

| Request | Cache-Control | Vary |
|---|---|---|
| `/static/…?v=<mtime>` | `public, max-age=31536000, immutable` | `Accept-Encoding` |
| `/static/…` (no buster) | `public, max-age=300` | `Accept-Encoding` |
| `dist/*` (`catch_all`) | `public, max-age=300, stale-while-revalidate=600` | `Accept-Encoding` |
| HTML, `sw.js`, route JSON | *unchanged* | `Cookie` |

Data is already up to ~40 min stale by design (`fetch_nostr` 30 min + `show` 10 min), so a 5-minute client cache is imperceptible. `stale-while-revalidate` serves instantly and refreshes in the background. `ETag`/`Last-Modified` are preserved, so a >15-min revalidation is a cheap `304`.

HTML stays revalidating on purpose — that's the invariant that makes immutable asset caching safe, since new `?v=` links must propagate on the next load. `sw.js` stays `no-cache` (it's the update mechanism).

## 🔒 Security fix found during review

The first implementation marked `/static/*` `public, max-age=31536000` — but Flask's `save_session()` still ran on those requests and **emitted `Set-Cookie: session=…` alongside it**. `SESSION_REFRESH_EACH_REQUEST` defaults to `True`, so any permanent session re-sends the cookie on *every* request. Reproduced directly: `/static/map.js` returned `public, max-age=31536000, immutable` **and** a live session cookie. A shared cache or CDN honouring `public` could store that response and serve one visitor's session to another.

Root cause: `Flask.process_response` runs all `@app.after_request` hooks and *then* calls `save_session()` as a hard-coded final step, so no hook can out-run it. `save_session` both emits `Set-Cookie` and appends `Vary: Cookie` (the latter on every request, since flask_security/flask_principal's identity loader touches `session` in `before_request` — even for static files).

**Fix:** `_CacheAwareSessionInterface` overrides `save_session` to **skip it entirely** for the `static` and `catch_all` endpoints. That prevents both the `Set-Cookie` and the `Vary: Cookie`. It's safe: those endpoints serve static files and pre-generated data, never mutate the session, and any session change is persisted by the next non-cacheable request.

`test_no_set_cookie_on_publicly_cacheable_responses` guards this, and was confirmed to **fail against the pre-fix code** (`Set-Cookie leaked on /static/map.js`) — it's a real guard, not a vacuous one.

## Second review finding

`immutable` was initially applied to *every* `/static/` URL — but only `map.html` uses `asset_url()`. `style.css` (from `ride_detail`, `report_ride`, `leaderboard`, `recent`), the marker icons and `countries.geojson` fetched from JS, `sw.js`'s icon and the manifest icons all arrive with **no `?v=`**. A year-long pin would have stranded clients on stale assets across deploys. Now only busted URLs get `immutable`; bare ones get `max-age=300` + ETag revalidation.

Also audited `dist/` — all files are public data (`dashboard.html`, `events`, `heatmap`, `rides_index`, `spots_recent`, `spots.json`); nothing user-specific is exposed by the `public` directive.

## Testing

- `tests/test_cache_headers.py` (new, 6 tests): busted vs bare static, dist SWR, HTML not long-cached, `Vary: Cookie` preserved on non-cacheable routes, and the no-`Set-Cookie` security guard.
- Full suite: **27 passed** (1 live-relay network test deselected). `ruff` clean.
- Live `curl` verification, including the precompressed `.gz` sidecar branch (keeps `Content-Encoding: gzip` + the SWR header) and the real 4.2 MB `spots.json`.

## Notes

- Headers only — no data-model or generation changes. Fully reversible.
- Clients holding old `no-cache` copies pick up the new headers on their next fetch; nothing to invalidate.
- Design: `docs/superpowers/specs/2026-07-10-cache-control-design.md` · Plan: `docs/superpowers/plans/2026-07-10-cache-control.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)