### PR TITLE
Account modal: handle login + profile on the map instead of navigating away (#106)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-account-modal.md
+++ b/docs/superpowers/plans/2026-07-10-account-modal.md
@@ -1,0 +1,250 @@
+# Account Modal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Open the account UI (logged-out login pitch, or username + insights + recent rides) in a modal so the map page never unloads. Issue #106.
+
+**Architecture:** A new `GET /me.json` serves the modal's data; an opt-in `?popup=1` variant of the OAuth flow lets login complete in a popup that `postMessage`s the opener; `account.js` renders the modal and intercepts the avatar click.
+
+**Design doc:** `docs/superpowers/specs/2026-07-10-account-modal-design.md`
+
+## Global Constraints
+
+- `/me.json` returns `200 {"logged_in": false}` for anonymous callers — never a 302 to `/login`.
+- `/me.json` sets `Cache-Control: private, no-store` and must never be `public`.
+- `rides` in `/me.json` is capped at `RIDES_IN_MODAL_CAP = 50`; `rides_total` is the untruncated count.
+- Ride entries omit the internal `submission_sort_key`.
+- The popup postMessage targets `window.location.origin` explicitly, never `"*"`. The opener validates `event.origin === window.location.origin` and `event.source === popupHandle`.
+- The non-popup OAuth flow is unchanged: callback still 302s to `/me` (existing user) or `/edit-user` (new user).
+- The account modal must NOT use `journeyUI._openDialog` (its single-flight guard tears down parent sheets).
+- The avatar stays an `<a href="/me">`; JS calls `preventDefault()`. Middle-click / no-JS still navigate.
+
+---
+
+### Task 1: `GET /me.json`
+
+**Files:**
+- Modify: `hitch/blueprints/user.py`
+- Test: `tests/test_me_json.py` (create)
+
+**Interfaces:**
+- Produces: `GET /me.json` → the payload in the design doc. Reuses `_distinct_partner_count(username)` and `_get_rides_for_user(user)`.
+
+- [ ] **Step 1: Write the failing tests** (`tests/test_me_json.py`)
+
+```python
+def test_me_json_anonymous_is_200_and_logged_out(client):
+    resp = client.get("/me.json")
+    assert resp.status_code == 200          # never a 302 to /login
+    assert resp.get_json() == {"logged_in": False}
+
+
+def test_me_json_is_never_publicly_cacheable(client):
+    resp = client.get("/me.json")
+    cc = resp.headers.get("Cache-Control", "")
+    assert "public" not in cc
+    assert "no-store" in cc
+
+
+def test_me_json_logged_in_payload(client, logged_in_user):
+    resp = client.get("/me.json")
+    body = resp.get_json()
+    assert body["logged_in"] is True
+    assert body["username"] == logged_in_user.username
+    assert body["profile_url"] == "/me"
+    assert set(body["insights"]) == {"rides", "distance_km", "waiting_min", "partners"}
+    assert isinstance(body["rides"], list)
+    assert body["rides_total"] >= len(body["rides"])
+    assert len(body["rides"]) <= 50
+    for r in body["rides"]:
+        assert "submission_sort_key" not in r
+```
+
+Add a `logged_in_user` fixture to `tests/conftest.py` that creates a `User` and sets `session["_user_id"]` via `client.session_transaction()` (login is OAuth, so there is no form to post).
+
+- [ ] **Step 2: Run to verify failure** — `.venv/bin/python -m pytest tests/test_me_json.py -v` → 404 / fixture error.
+
+- [ ] **Step 3: Implement** in `hitch/blueprints/user.py`:
+
+```python
+RIDES_IN_MODAL_CAP = 50
+
+
+@user_bp.route("/me.json", methods=["GET"])
+def me_json():
+    """Account data for the on-map modal (issue #106).
+
+    Anonymous callers get 200 {"logged_in": false} rather than a redirect to /login:
+    the modal renders its logged-out state from this response and must never follow a 302.
+    """
+    if current_user.is_anonymous:
+        resp = jsonify({"logged_in": False})
+    else:
+        rides = _get_rides_for_user(current_user)
+        shown = [{k: v for k, v in r.items() if k != "submission_sort_key"} for r in rides[:RIDES_IN_MODAL_CAP]]
+        resp = jsonify({
+            "logged_in": True,
+            "username": current_user.username,
+            "needs_profile": not bool(current_user.hitchwiki_username),
+            "profile_url": "/me",
+            "insights": {
+                "rides": current_user.total_rides or 0,
+                "distance_km": current_user.total_distance_km or 0,
+                "waiting_min": current_user.total_waiting_time_min or 0,
+                "partners": _distinct_partner_count(current_user.username),
+            },
+            "rides": shown,
+            "rides_total": len(rides),
+        })
+    # Per-user data: never let a shared cache store or reuse it (see PR #105).
+    resp.headers["Cache-Control"] = "private, no-store"
+    return resp
+```
+
+- [ ] **Step 4: Verify pass**, then `.venv/bin/ruff check hitch/ tests/`.
+
+- [ ] **Step 5: Commit** — `feat(account): serve /me.json for the on-map account modal`
+
+---
+
+### Task 2: OAuth popup completion
+
+**Files:**
+- Modify: `hitch/blueprints/oauth.py`
+- Create: `hitch/templates/security/oauth_popup_done.html`
+- Test: `tests/test_oauth_popup.py` (create)
+
+**Interfaces:**
+- Consumes: `/login/oauth?popup=1`.
+- Produces: callback renders `oauth_popup_done.html` (200) when `session["oauth_popup"]`, else the existing 302.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_popup_flag_is_set_and_state_still_stored(client):
+    resp = client.get("/login/oauth?popup=1")
+    assert resp.status_code == 302          # still redirects to Hitchwiki
+    with client.session_transaction() as sess:
+        assert sess["oauth_popup"] is True
+        assert sess["oauth_state"]
+
+
+def test_plain_login_oauth_sets_no_popup_flag(client):
+    client.get("/login/oauth")
+    with client.session_transaction() as sess:
+        assert "oauth_popup" not in sess
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement.** In `login_oauth`, before redirecting:
+
+```python
+    # The Hitchwiki redirect back carries only `code` and `state`, so remember here
+    # that the flow began in a popup; the callback needs it to close the popup
+    # instead of navigating the (hidden) window to /me.
+    if request.args.get("popup"):
+        session["oauth_popup"] = True
+    else:
+        session.pop("oauth_popup", None)
+```
+
+In `_handle_callback`, replace each terminal `redirect(...)` with a helper:
+
+```python
+def _finish_login(target, needs_profile):
+    """End the OAuth flow: close the popup, or redirect a full-page flow as before."""
+    if session.pop("oauth_popup", False):
+        return render_template("security/oauth_popup_done.html", needs_profile=needs_profile)
+    return redirect(target)
+```
+
+`oauth_popup_done.html` posts to the opener at our own origin and closes:
+
+```html
+<script>
+  (function () {
+    var msg = { type: "hitchwiki-auth", ok: true, needsProfile: {{ needs_profile|tojson }} };
+    // Same-origin by construction: target our own origin explicitly, never "*".
+    if (window.opener) window.opener.postMessage(msg, window.location.origin);
+    window.close();
+  })();
+</script>
+<p>Signed in. You can close this window.</p>
+```
+
+- [ ] **Step 4: Verify pass + ruff.**
+- [ ] **Step 5: Commit** — `feat(oauth): allow the login flow to complete in a popup`
+
+---
+
+### Task 3: The modal
+
+**Files:**
+- Create: `hitch/static/account.js`
+- Modify: `hitch/templates/map.html` (load the script), `hitch/static/style.css`
+- Test: `tests/account.test.js` (create)
+
+**Interfaces:**
+- Consumes: `GET /me.json`, `/login/oauth?popup=1`.
+- Produces: `window.AccountModal.open()`; pure helpers `formatInsights(insights)` and `ridesSummary(shown, total)` exported for node.
+
+- [ ] **Step 1: Write the failing node tests** (`tests/account.test.js`) for the pure helpers:
+
+```js
+const A = require("../hitch/static/account.js");
+test("ridesSummary reports truncation", () => {
+  assert.strictEqual(A.ridesSummary(50, 231), "Showing 50 of 231 rides");
+  assert.strictEqual(A.ridesSummary(3, 3), "3 rides");
+});
+test("formatInsights rounds distance and formats waiting time", () => {
+  const s = A.formatInsights({ rides: 42, distance_km: 5312.44, waiting_min: 980, partners: 7 });
+  assert.strictEqual(s.distance, "5,312 km");
+  assert.strictEqual(s.waiting, "16 h 20 m");
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `node --test tests/account.test.js`.
+
+- [ ] **Step 3: Implement `account.js`.** Dual export (browser `window.AccountModal` + CommonJS) like `ride_submit.js`. Must include:
+  - `open()` → build scrim + sheet, `L.DomEvent.disableClickPropagation` on the sheet, fetch `/me.json`, render.
+  - Logged-out render: pitch + "Log in with Hitchwiki" button → `startLogin()`.
+  - `startLogin()`:
+    ```js
+    const popup = window.open("/login/oauth?popup=1", "hitchwiki-login", "width=520,height=640");
+    if (!popup) { window.location.href = "/login/oauth"; return; }   // popup blocked (mobile Safari)
+    function onMsg(e) {
+      // Only trust a message from OUR origin, sent by the popup we opened.
+      if (e.origin !== window.location.origin || e.source !== popup) return;
+      if (!e.data || e.data.type !== "hitchwiki-auth") return;
+      window.removeEventListener("message", onMsg);
+      refresh(e.data.needsProfile);
+    }
+    window.addEventListener("message", onMsg);
+    ```
+  - Logged-in render: username, insight summary, first 10 rides, a "Show all" button revealing the rest, `needs_profile` → "Finish setting up your profile" link to `/edit-user`, and "View full profile" → `profile_url`.
+  - Own scrim + Escape/scrim dismissal. Do **not** touch `journeyUI._openDialog`.
+
+- [ ] **Step 4: Wire the avatar** in `hitch/templates/map.html` — keep `<a href="/me">`, add `id`, and in `account.js`:
+  ```js
+  link.addEventListener("click", function (e) {
+    if (e.metaKey || e.ctrlKey || e.button === 1) return;  // let new-tab through
+    e.preventDefault();
+    AccountModal.open();
+  });
+  ```
+  Load `<script src="{{ asset_url('/static/account.js') }}"></script>` (asset_url gives the `?v=` buster that PR #105's immutable caching keys on).
+
+- [ ] **Step 5: Style** `.acct-*` classes in `style.css`, matching the in-ride sheet.
+
+- [ ] **Step 6: Verify** — `node --test tests/*.test.js`, `node --check hitch/static/account.js`, full pytest, ruff.
+
+- [ ] **Step 7: Commit** — `feat(account): open login + profile in an on-map modal`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** `/me.json` + anon 200 + cache header + ride cap (Task 1); popup flag, postMessage page, unchanged full-page flow (Task 2); modal render, popup-blocked fallback, origin+source validation, avatar interception, no `_openDialog` (Task 3).
+- **Placeholders:** none.
+- **Type consistency:** `needs_profile` (JSON, snake) ↔ `needsProfile` (postMessage, camel) is deliberate and stated in both tasks; `RIDES_IN_MODAL_CAP = 50` used in Task 1 and asserted in its test.

--- a/docs/superpowers/specs/2026-07-10-account-modal-design.md
+++ b/docs/superpowers/specs/2026-07-10-account-modal-design.md
@@ -1,0 +1,97 @@
+# Account modal (login + profile without leaving the map) — Design
+
+**Date:** 2026-07-10
+**Issue:** #106
+**Branch:** `feature/account-modal` (from `main`)
+
+## Problem
+
+The account button is a plain link — `<a href="/me">` (`hitch/templates/map.html:533`). Tapping it unloads the map: an in-progress in-ride journey loses its dock and open sheets, test mode exits, the viewport / open spot pane / planned route are discarded, and returning re-downloads `spots.json` (4.2 MB) and `rides_index.json` (26.5 MB).
+
+## Goal
+
+The avatar opens a **modal**; the map page never unloads. The modal serves both auth states.
+
+**Logged in:** username, insight summary, the 10 most recent rides (expandable), and a link out to the full web profile.
+**Logged out:** a short pitch plus "Log in with Hitchwiki".
+
+Out of scope (stays on the web profile): editing, trips, follow/unfollow, notifications, achievement ladders.
+
+## The login constraint
+
+Login is Hitchwiki OAuth2, not a local password form. `oauth.login_oauth` (`hitch/blueprints/oauth.py:47`) redirects to `hitchwiki.org/rest.php/oauth2/authorize`; the callback hard-redirects to `/me`, or `/edit-user` for a first-time user. There is no `next`/return-to. **A modal cannot host the credential form.**
+
+### Popup + postMessage
+
+```
+avatar tap → modal (logged out)
+    [ Log in with Hitchwiki ]
+          ↓ window.open("/login/oauth?popup=1")
+    popup: hitchwiki.org/authorize
+          ↓ callback (?code=) on OUR origin
+    popup renders a tiny page that postMessages the opener, then closes
+    modal re-renders logged-in; map never unloaded
+```
+
+- `/login/oauth?popup=1` sets `session["oauth_popup"] = True` alongside the existing `oauth_state`. The flag rides the session across the Hitchwiki round trip, so the callback knows the flow began in a popup — the redirect back from Hitchwiki carries only `code` and `state`, nothing of ours.
+- The callback, when `oauth_popup` is set, pops the flag and renders `oauth_popup_done.html` instead of redirecting. That page calls `window.opener.postMessage({type:"hitchwiki-auth", ok:true, needsProfile:<bool>}, <our origin>)` and `window.close()`.
+- **Security:** the popup page is served from our own origin, so it targets `window.location.origin` explicitly (never `"*"`). The opener validates `event.origin === window.location.origin` **and** `event.source === popupHandle` before trusting the message. The existing CSRF-ish `state` check in `_handle_callback` is untouched and still guards the OAuth exchange itself.
+- **Popup blocked** (common on mobile Safari): `window.open` returns `null` (or throws). Fall back to a full-page `location.href = "/login/oauth"` — today's behavior. Ride state already survives in `localStorage`; the viewport is in the URL.
+- **First-time users** currently land on `/edit-user`. In the popup flow the callback still creates + logs in the user, but reports `needsProfile: true`; the modal then renders a "Finish setting up your profile" link rather than silently swallowing the step.
+
+## Data
+
+Everything is already computed server-side. No new aggregation.
+
+| Field | Source |
+|---|---|
+| `total_rides`, `total_distance_km`, `total_waiting_time_min` | precomputed columns on the `user` row (`hitch/models.py:43-45`), written by `show.py` |
+| distinct partner count | `_distinct_partner_count(username)` (`user.py:228`) |
+| recent rides | `_get_rides_for_user(user)` (`user.py:554`), newest first |
+
+### `GET /me.json`
+
+New route on `user_bp`, modelled on the existing `/user` JSON endpoint (`user.py:64`).
+
+- **Anonymous → `200 {"logged_in": false}`.** Never a 302 to `/login`; the modal needs to render its logged-out state from this response.
+- **Logged in → `200`:**
+
+```json
+{
+  "logged_in": true,
+  "username": "kim",
+  "needs_profile": false,
+  "profile_url": "/me",
+  "insights": {"rides": 42, "distance_km": 5312.4, "waiting_min": 980, "partners": 7},
+  "rides": [{"d_tag": "...", "created": "2026-07-01T12:00:00", "rating": 4,
+             "comment": "…", "type": "own",
+             "pickup_lat": 1.0, "pickup_lon": 2.0,
+             "destination_lat": 3.0, "destination_lon": 4.0}],
+  "rides_total": 42
+}
+```
+
+- `rides` is capped at **50** (`RIDES_IN_MODAL_CAP`). The modal shows 10 and expands to reveal the rest client-side — no pagination for the MVP. `rides_total` is the untruncated count so the UI can say "showing 50 of 231" and point at the full profile.
+- Ride entries are `_extract_ride_info` output minus `submission_sort_key` (an internal sort artifact).
+
+**Caching.** This response is per-user. PR #105 made `/static/*` and `dist/*` publicly cacheable, but that hook is keyed on the `static` / `catch_all` endpoints, so a route endpoint like this is untouched and keeps `Vary: Cookie`. That is a fact to *pin down*, not assume: the route sets `Cache-Control: private, no-store` explicitly, and a test asserts it is never `public`. A shared cache serving one user's profile to another is the exact failure mode #105 already had to fix once.
+
+## UI
+
+New `hitch/static/account.js` (browser + CommonJS dual export, like `ride_submit.js`, so the pure parts are node-testable).
+
+- The avatar stays an `<a href="/me">` so it works without JS and for middle-click / "open in new tab". A click handler calls `preventDefault()` and opens the modal instead.
+- The modal reuses the in-ride sheet look (scrim + sheet, `disableClickPropagation` so taps never reach Leaflet). It does **not** reuse `journeyUI._openDialog` — that single-flight guard tears down a parent sheet when a second one opens (this bit us in #102). The account modal is a peer, with its own scrim and its own escape/scrim-dismiss.
+- Rendering is data-driven off `/me.json`, fetched on open (not at page load — most visits never open it).
+- Logged-out body: one sentence on what an account buys, then the login button.
+
+## Testing
+
+- **pytest:** `/me.json` anonymous → `{"logged_in": false}`, 200, not `public`; logged in → the full payload, ride cap honoured, `rides_total` reflects the untruncated count; `Cache-Control` is `private, no-store` and `Vary` does not advertise the response as publicly cacheable.
+- **pytest:** `/login/oauth?popup=1` sets the session flag; the callback with the flag renders the postMessage page (not a 302) and clears the flag; without the flag it still 302s to `/me` (no regression to the normal flow).
+- **node:** pure render helpers in `account.js` (e.g. the insight-summary formatter and the "showing N of M" logic).
+- Manual: popup-blocked fallback on mobile Safari; an in-ride journey and test mode both survive opening/closing the modal.
+
+## Rollout
+
+Additive. The existing `/me`, `/account/<username>`, and `/insights/<username>` pages are unchanged and remain the link target. Reverting is removing the click handler.

--- a/example.env
+++ b/example.env
@@ -30,6 +30,13 @@ HITCHWIKI_OAUTH_CLIENT_ID = afd23fc3ac2d225d39de8b361e956aef # use aa159948f2af3
 # keep this private
 HITCHWIKI_OAUTH_CLIENT_SECRET = xxx
 
+# Tunnel-based OAuth testing (cloudflared / ngrok). The consumer's registered callback is
+# compared byte-for-byte, and url_for() would derive the tunnel's random hostname, which is
+# registered nowhere. Pin the exact origin here and register "<that origin>/login" as the
+# consumer's callback. Leave unset for normal local (127.0.0.1) and production use.
+# HITCHWIKI_OAUTH_REDIRECT_BASE = https://your-tunnel.trycloudflare.com
+# HITCHWIKI_OAUTH_REDIRECT_SCHEME = https
+
 # choose prod or dev
 # TODO
 ENVIRONMENT=xxx

--- a/hitch/blueprints/oauth.py
+++ b/hitch/blueprints/oauth.py
@@ -43,11 +43,29 @@ def login():
     return render_template("security/login_user.html")
 
 
+def _finish_login(target, needs_profile):
+    """End the OAuth flow.
+
+    A popup-initiated login (see login_oauth) must not navigate the popup to /me — the
+    opener is the map, and it stays put. Render a page that hands the result back to the
+    opener and closes itself. A normal full-page login redirects exactly as before.
+    """
+    if session.pop("oauth_popup", False):
+        return render_template("security/oauth_popup_done.html", needs_profile=needs_profile)
+    return redirect(target)
+
+
 @oauth_bp.route("/login/oauth")
 def login_oauth():
     """Start the OAuth2 redirect to Hitchwiki."""
     state = secrets.token_urlsafe(32)
     session["oauth_state"] = state
+    # Hitchwiki redirects back with only `code` and `state`, so nothing of ours survives
+    # the round trip except the session — record here that the flow began in a popup.
+    if request.args.get("popup"):
+        session["oauth_popup"] = True
+    else:
+        session.pop("oauth_popup", None)
 
     authorize_url = f"{_wiki_base()}/rest.php/oauth2/authorize"
     params = {
@@ -146,7 +164,9 @@ def _handle_callback(code):
         maybe_send_welcome_email(user)
         # Seed the default in-app welcome notification (idempotent).
         ensure_welcome_notification(user)
-        return redirect("/edit-user")
+        # Brand-new user: only the callback knows this, so it rides the postMessage /
+        # redirect rather than being re-derived later from the user row.
+        return _finish_login("/edit-user", needs_profile=True)
 
     # Existing user - just log in
     login_user(user, remember=True)
@@ -156,4 +176,4 @@ def _handle_callback(code):
     # Back-fills the welcome notification for users who registered before notifications
     # existed; idempotent, so existing users get it exactly once.
     ensure_welcome_notification(user)
-    return redirect("/me")
+    return _finish_login("/me", needs_profile=False)

--- a/hitch/blueprints/oauth.py
+++ b/hitch/blueprints/oauth.py
@@ -29,7 +29,14 @@ def _redirect_uri():
     league/oauth2-server rejects it as "Client authentication failed" -- the same
     message it gives for an unknown client. The scheme can't be inferred from the
     request (see HITCHWIKI_OAUTH_REDIRECT_SCHEME in settings.py), so state it.
+
+    HITCHWIKI_OAUTH_REDIRECT_BASE overrides the whole origin. Behind a tunnel, url_for()
+    derives the origin from the request, which yields a hostname the consumer has never
+    heard of; pinning the origin lets a tunnel URL be registered and used verbatim.
     """
+    base = current_app.config.get("HITCHWIKI_OAUTH_REDIRECT_BASE")
+    if base:
+        return base.rstrip("/") + url_for("oauth.login")
     return url_for("oauth.login", _external=True, _scheme=current_app.config["HITCHWIKI_OAUTH_REDIRECT_SCHEME"])
 
 

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -73,6 +73,46 @@ def get_user():
         return jsonify({"logged_in": False, "username": ""})
 
 
+# The modal shows 10 rides and expands to the rest of this slice; beyond it we send the
+# user to the full profile rather than shipping an unbounded ride list to every opener.
+RIDES_IN_MODAL_CAP = 50
+
+
+@user_bp.route("/me.json", methods=["GET"])
+def me_json():
+    """Account data for the on-map account modal (issue #106).
+
+    Anonymous callers get 200 {"logged_in": false} rather than the 302 to /login that
+    /me serves: the modal renders its logged-out state from this response, and fetch()
+    would silently follow the redirect and hand us a login page instead of JSON.
+    """
+    if current_user.is_anonymous:
+        resp = jsonify({"logged_in": False})
+    else:
+        rides = _get_rides_for_user(current_user)
+        shown = [{k: v for k, v in r.items() if k != "submission_sort_key"} for r in rides[:RIDES_IN_MODAL_CAP]]
+        resp = jsonify(
+            {
+                "logged_in": True,
+                "username": current_user.username,
+                "profile_url": "/me",
+                "insights": {
+                    "rides": current_user.total_rides or 0,
+                    "distance_km": current_user.total_distance_km or 0,
+                    "waiting_min": current_user.total_waiting_time_min or 0,
+                    "partners": _distinct_partner_count(current_user.username),
+                },
+                "rides": shown,
+                # Untruncated, so the UI can say "showing 50 of 231" and link to the profile.
+                "rides_total": len(rides),
+            }
+        )
+    # Per-user data. A shared cache storing this could serve one user's profile to
+    # another — the exact failure mode the cache-control work had to fix once already.
+    resp.headers["Cache-Control"] = "private, no-store"
+    return resp
+
+
 # TODO: properly delete the user after their confirmation
 @user_bp.route("/delete-user", methods=["GET"])
 def delete_user():

--- a/hitch/settings.py
+++ b/hitch/settings.py
@@ -49,7 +49,14 @@ class BaseConfig:
     # any mismatch as "Client authentication failed", the same error it gives an unknown
     # client. The dev consumer is registered with http://127.0.0.1:5001/login, so http
     # is the default and only production overrides it.
-    HITCHWIKI_OAUTH_REDIRECT_SCHEME = "http"
+    HITCHWIKI_OAUTH_REDIRECT_SCHEME = os.getenv("HITCHWIKI_OAUTH_REDIRECT_SCHEME", "http")
+
+    # Full origin to build the OAuth redirect_uri from, e.g.
+    # "https://my-tunnel.trycloudflare.com". Needed when the app is reached through a
+    # tunnel: url_for() would otherwise derive the origin from the request, and the
+    # scheme/host it infers won't byte-match the consumer's registered callback. Leave
+    # unset everywhere except tunnel-based local testing; production derives its own.
+    HITCHWIKI_OAUTH_REDIRECT_BASE = os.getenv("HITCHWIKI_OAUTH_REDIRECT_BASE")
 
     # Lax allows the session cookie to be sent on top-level navigations (needed for OAuth redirects).
     # Strict would block the cookie when returning from hitchwiki.org, breaking the OAuth flow.

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -1,0 +1,230 @@
+// Account modal: login + profile summary without leaving the map (issue #106).
+//
+// Tapping the avatar used to navigate to /me, unloading the map — an in-progress ride
+// lost its dock, test mode exited, and coming back re-downloaded spots.json (4.2 MB)
+// and rides_index.json (26.5 MB). This renders the same essentials in a sheet instead.
+//
+// Dual export (browser + CommonJS) so the pure formatters are testable under node,
+// matching ride_submit.js.
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== "undefined" && module.exports) module.exports = mod;
+  else root.AccountModal = mod;
+})(typeof self !== "undefined" ? self : this, function () {
+  "use strict";
+
+  const RIDES_SHOWN_COLLAPSED = 10;
+
+  // ── Pure formatters (unit-tested) ──────────────────────────────────────────
+
+  function formatInsights(insights) {
+    const i = insights || {};
+    const km = Math.round(i.distance_km || 0);
+    const mins = Math.round(i.waiting_min || 0);
+    const hours = Math.floor(mins / 60);
+    return {
+      rides: String(i.rides || 0),
+      distance: km.toLocaleString("en-US") + " km",
+      // Waiting time reads as hours once it passes an hour; minutes alone below that.
+      waiting: hours > 0 ? hours + " h " + (mins % 60) + " m" : mins + " m",
+      partners: String(i.partners || 0),
+    };
+  }
+
+  // `shown` is what the payload carried (capped server-side); `total` is the real count.
+  function ridesSummary(shown, total) {
+    if (total > shown) return "Showing " + shown + " of " + total + " rides";
+    return total + (total === 1 ? " ride" : " rides");
+  }
+
+  function rideLabel(ride) {
+    const when = (ride.created || "").slice(0, 10);
+    const stars = ride.rating ? "★".repeat(ride.rating) : "";
+    return { when: when, stars: stars, comment: (ride.comment || "").trim() };
+  }
+
+  // ── DOM (browser only) ─────────────────────────────────────────────────────
+
+  let _open = null; // { close }
+
+  function el(tag, cls, text) {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text;
+    return e;
+  }
+
+  function close() {
+    if (!_open) return;
+    _open.teardown();
+    _open = null;
+  }
+
+  function open() {
+    // The account modal is a peer of the in-ride sheets, not a child: it deliberately
+    // does NOT register with journeyUI._openDialog, whose single-flight guard closes the
+    // parent whenever a second sheet opens.
+    if (_open) return _open;
+
+    const scrim = el("div", "inride-scrim acct-scrim");
+    const sheet = el("div", "inr-sheet inr-sheet--scroll acct-sheet");
+
+    // Taps on the sheet must never reach Leaflet underneath (would drop a pin / open a spot).
+    if (window.L && window.L.DomEvent) window.L.DomEvent.disableClickPropagation(sheet);
+
+    sheet.appendChild(el("div", "inr-sheet__grab"));
+    const closeX = el("button", "inr-sheet__close");
+    closeX.type = "button";
+    closeX.setAttribute("aria-label", "Close");
+    closeX.innerHTML = "&times;";
+    closeX.addEventListener("click", close);
+    sheet.appendChild(closeX);
+
+    const body = el("div", "acct-body");
+    body.appendChild(el("p", "acct-loading", "Loading…"));
+    sheet.appendChild(body);
+
+    function onKey(e) {
+      if (e.key === "Escape") close();
+    }
+    function teardown() {
+      document.removeEventListener("keydown", onKey);
+      if (scrim.parentNode) scrim.parentNode.removeChild(scrim);
+      if (sheet.parentNode) sheet.parentNode.removeChild(sheet);
+    }
+
+    scrim.addEventListener("click", close);
+    document.addEventListener("keydown", onKey);
+    document.body.appendChild(scrim);
+    document.body.appendChild(sheet);
+    _open = { close: close, teardown: teardown, body: body };
+
+    refresh();
+    return _open;
+  }
+
+  function refresh(needsProfile) {
+    if (!_open) return;
+    const body = _open.body;
+    fetch("/me.json", { credentials: "same-origin" })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        body.innerHTML = "";
+        if (data && data.logged_in) renderLoggedIn(body, data, needsProfile);
+        else renderLoggedOut(body);
+      })
+      .catch(function () {
+        body.innerHTML = "";
+        body.appendChild(el("p", "acct-error", "Couldn't load your account. Check your connection."));
+      });
+  }
+
+  function renderLoggedOut(body) {
+    body.appendChild(el("h4", null, "Your rides, saved"));
+    body.appendChild(
+      el("p", "acct-pitch", "Log in to track your hitchhiking, keep your ride history, and see your stats.")
+    );
+    const btn = el("button", "inr-big inr-big--green");
+    btn.type = "button";
+    btn.innerHTML = '<i class="fa-solid fa-right-to-bracket"></i> Log in with Hitchwiki';
+    btn.addEventListener("click", startLogin);
+    body.appendChild(btn);
+  }
+
+  function renderLoggedIn(body, data, needsProfile) {
+    body.appendChild(el("h4", "acct-username", data.username));
+
+    if (needsProfile) {
+      const nudge = el("a", "acct-nudge");
+      nudge.href = "/edit-user";
+      nudge.textContent = "Finish setting up your profile →";
+      body.appendChild(nudge);
+    }
+
+    const s = formatInsights(data.insights);
+    const stats = el("div", "acct-stats");
+    [
+      ["Rides", s.rides],
+      ["Distance", s.distance],
+      ["Waiting", s.waiting],
+      ["Partners", s.partners],
+    ].forEach(function (pair) {
+      const cell = el("div", "acct-stat");
+      cell.appendChild(el("span", "acct-stat__val", pair[1]));
+      cell.appendChild(el("span", "acct-stat__label", pair[0]));
+      stats.appendChild(cell);
+    });
+    body.appendChild(stats);
+
+    const rides = data.rides || [];
+    body.appendChild(el("div", "acct-rides-head", ridesSummary(rides.length, data.rides_total || rides.length)));
+
+    const list = el("ul", "acct-rides");
+    rides.forEach(function (ride, idx) {
+      const li = el("li", "acct-ride");
+      if (idx >= RIDES_SHOWN_COLLAPSED) li.classList.add("acct-ride--hidden");
+      const info = rideLabel(ride);
+      li.appendChild(el("span", "acct-ride__when", info.when));
+      if (info.stars) li.appendChild(el("span", "acct-ride__stars", info.stars));
+      if (info.comment) li.appendChild(el("span", "acct-ride__comment", info.comment));
+      list.appendChild(li);
+    });
+    body.appendChild(list);
+
+    if (rides.length > RIDES_SHOWN_COLLAPSED) {
+      const more = el("button", "acct-more", "Show all " + rides.length);
+      more.type = "button";
+      more.addEventListener("click", function () {
+        list.querySelectorAll(".acct-ride--hidden").forEach(function (n) {
+          n.classList.remove("acct-ride--hidden");
+        });
+        more.remove();
+      });
+      body.appendChild(more);
+    }
+
+    const profile = el("a", "acct-profile-link");
+    profile.href = data.profile_url || "/me";
+    profile.textContent = "View full profile →";
+    body.appendChild(profile);
+  }
+
+  // Login is Hitchwiki OAuth: a full-page redirect we cannot host inline. Run it in a
+  // popup and let the callback postMessage the result back, so the map stays loaded.
+  function startLogin() {
+    const popup = window.open("/login/oauth?popup=1", "hitchwiki-login", "width=520,height=640");
+    if (!popup) {
+      // Popup blocked (routine on mobile Safari) — fall back to today's full-page flow.
+      // The in-ride journey lives in localStorage, and the viewport is in the URL.
+      window.location.href = "/login/oauth";
+      return;
+    }
+    function onMsg(e) {
+      // Trust only a message from our own origin, sent by the window we opened.
+      if (e.origin !== window.location.origin) return;
+      if (e.source !== popup) return;
+      if (!e.data || e.data.type !== "hitchwiki-auth") return;
+      window.removeEventListener("message", onMsg);
+      refresh(e.data.needsProfile);
+    }
+    window.addEventListener("message", onMsg);
+  }
+
+  function init() {
+    const link = document.querySelector("#top-account-btn a");
+    if (!link) return;
+    link.addEventListener("click", function (e) {
+      // Let the browser handle new-tab/new-window intents and any modified click.
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      e.preventDefault();
+      open();
+    });
+  }
+
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+    else init();
+  }
+
+  return { open: open, close: close, formatInsights: formatInsights, ridesSummary: ridesSummary, rideLabel: rideLabel };
+});

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -2754,3 +2754,82 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
    peek: 88 in map.js), overriding the generic .snap-peek (80%), so most of the map
    stays visible. The pane can't be swiped away — only the X closes it. */
 .sidebar.routing.bottom-sheet.snap-peek { transform: translateY(88%); }
+
+/* ── Account modal (issue #106): login + profile summary without leaving the map ──
+   Reuses the in-ride sheet shell (.inr-sheet / .inride-scrim) but is a peer of those
+   sheets, never registered with journeyUI._openDialog. */
+.acct-sheet { z-index: 3000; }
+.acct-scrim { z-index: 2999; }
+.acct-body { display: flex; flex-direction: column; }
+.acct-username { margin: 2px 0 10px; font-size: 20px; }
+.acct-pitch { color: #555; font-size: 14px; margin: 0 0 14px; }
+.acct-loading, .acct-error { color: #888; font-size: 14px; }
+.acct-nudge {
+  display: block;
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #8a6d00;
+  text-decoration: none;
+}
+
+/* Four-up lifetime totals */
+.acct-stats { display: flex; gap: 8px; margin-bottom: 14px; }
+.acct-stat {
+  flex: 1;
+  background: #f6f6f6;
+  border-radius: 10px;
+  padding: 9px 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+.acct-stat__val { font-size: 15px; font-weight: 800; color: #222; }
+.acct-stat__label { font-size: 11px; color: #777; text-transform: uppercase; letter-spacing: .03em; }
+
+.acct-rides-head { font-size: 12px; font-weight: 700; color: #666; margin-bottom: 6px; }
+.acct-rides { list-style: none; margin: 0 0 10px; padding: 0; }
+.acct-ride {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 13px;
+}
+.acct-ride--hidden { display: none; }
+.acct-ride__when { color: #888; font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.acct-ride__stars { color: #f5a623; flex-shrink: 0; }
+.acct-ride__comment {
+  color: #444;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.acct-more {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #2f80ed;
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 4px 0;
+  margin-bottom: 8px;
+}
+.acct-profile-link {
+  display: block;
+  text-align: center;
+  padding: 11px;
+  border-radius: 10px;
+  background: #f2f6fd;
+  color: #2f80ed;
+  font-weight: 700;
+  font-size: 14px;
+  text-decoration: none;
+}

--- a/hitch/templates/map.html
+++ b/hitch/templates/map.html
@@ -69,6 +69,7 @@ var HIDE_ACCOUNT_BUTTON = {{ hide_account_button|tojson }};
 <script src="{{ asset_url('/static/map.js') }}"></script>
 <script src="{{ asset_url('/static/routing.js') }}"></script>
 <script src="{{ asset_url('/static/inride.js') }}"></script>
+<script src="{{ asset_url('/static/account.js') }}"></script>
 <script>
 // Install-to-homescreen hint logic. Self-contained — no dependency on map.js.
 // Storage key holds the dismissal timestamp (ms); reappears after 30 days.

--- a/hitch/templates/security/oauth_popup_done.html
+++ b/hitch/templates/security/oauth_popup_done.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Signed in</title>
+  <meta name="robots" content="noindex" />
+</head>
+<body>
+  <p>Signed in. You can close this window.</p>
+  <script>
+    (function () {
+      var msg = {
+        type: "hitchwiki-auth",
+        ok: true,
+        needsProfile: {{ needs_profile|tojson }}
+      };
+      // This page is served from our own origin, so address the opener at that exact
+      // origin. A wildcard target would let any window read the message.
+      if (window.opener) {
+        try { window.opener.postMessage(msg, window.location.origin); } catch (e) {}
+      }
+      window.close();
+      // If the browser refuses to close a window it didn't script-open, the user still
+      // needs a way out — and a brand-new account still needs its profile filled in.
+      window.setTimeout(function () {
+        window.location.href = {{ ("/edit-user" if needs_profile else "/me")|tojson }};
+      }, 800);
+    })();
+  </script>
+</body>
+</html>

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const A = require("../hitch/static/account.js");
+
+test("ridesSummary reports truncation, and pluralises when complete", () => {
+  assert.strictEqual(A.ridesSummary(50, 231), "Showing 50 of 231 rides");
+  assert.strictEqual(A.ridesSummary(3, 3), "3 rides");
+  assert.strictEqual(A.ridesSummary(1, 1), "1 ride");
+  assert.strictEqual(A.ridesSummary(0, 0), "0 rides");
+});
+
+test("formatInsights rounds distance and turns minutes into hours", () => {
+  const s = A.formatInsights({ rides: 42, distance_km: 5312.44, waiting_min: 980, partners: 7 });
+  assert.strictEqual(s.rides, "42");
+  assert.strictEqual(s.distance, "5,312 km");
+  assert.strictEqual(s.waiting, "16 h 20 m");
+  assert.strictEqual(s.partners, "7");
+});
+
+test("formatInsights keeps sub-hour waits in minutes", () => {
+  assert.strictEqual(A.formatInsights({ waiting_min: 45 }).waiting, "45 m");
+});
+
+test("formatInsights survives a missing/empty insights object", () => {
+  const s = A.formatInsights(undefined);
+  assert.strictEqual(s.rides, "0");
+  assert.strictEqual(s.distance, "0 km");
+  assert.strictEqual(s.waiting, "0 m");
+  assert.strictEqual(s.partners, "0");
+});
+
+test("rideLabel extracts date, stars and trimmed comment", () => {
+  const r = A.rideLabel({ created: "2026-07-01T12:00:00", rating: 4, comment: "  nice driver " });
+  assert.strictEqual(r.when, "2026-07-01");
+  assert.strictEqual(r.stars, "★★★★");
+  assert.strictEqual(r.comment, "nice driver");
+});
+
+test("rideLabel tolerates a ride with no rating or comment", () => {
+  const r = A.rideLabel({ created: "2026-07-01T12:00:00" });
+  assert.strictEqual(r.stars, "");
+  assert.strictEqual(r.comment, "");
+});

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -1,0 +1,87 @@
+"""Tests for /me.json, the data source for the on-map account modal (issue #106)."""
+
+import pytest
+
+from hitch.blueprints.user import RIDES_IN_MODAL_CAP
+from hitch.extensions import db as _db
+from hitch.models import User
+
+
+@pytest.fixture
+def logged_in_user(app, client):
+    """Create a user and log them in.
+
+    Login is Hitchwiki OAuth (no local password form to POST), so seed Flask-Login's
+    session key directly — the same thing login_user() ultimately does.
+    """
+    with app.app_context():
+        user = User(
+            username="testhitcher",
+            email="testhitcher@example.com",
+            password="x",
+            active=True,
+            fs_uniquifier="me-json-test-uniquifier",
+            total_rides=42,
+            total_distance_km=5312.44,
+            total_waiting_time_min=980,
+        )
+        _db.session.add(user)
+        _db.session.commit()
+        user_id = user.id
+        username = user.username
+
+    with client.session_transaction() as sess:
+        # Flask-Security's UserMixin.get_id() returns fs_uniquifier, not the PK, so that
+        # is what Flask-Login stores and looks up.
+        sess["_user_id"] = "me-json-test-uniquifier"
+        sess["_fresh"] = True
+
+    yield type("U", (), {"id": user_id, "username": username})
+
+    with app.app_context():
+        u = _db.session.get(User, user_id)
+        if u:
+            _db.session.delete(u)
+            _db.session.commit()
+
+
+def test_me_json_anonymous_is_200_and_logged_out(client):
+    # Must not 302 to /login: fetch() would follow it and hand the modal an HTML page.
+    resp = client.get("/me.json")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"logged_in": False}
+
+
+def test_me_json_is_never_publicly_cacheable(client):
+    resp = client.get("/me.json")
+    cache_control = resp.headers.get("Cache-Control", "")
+    assert "public" not in cache_control
+    assert "no-store" in cache_control
+
+
+def test_me_json_logged_in_payload(client, logged_in_user):
+    resp = client.get("/me.json")
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    assert body["logged_in"] is True
+    assert body["username"] == logged_in_user.username
+    assert body["profile_url"] == "/me"
+
+    assert set(body["insights"]) == {"rides", "distance_km", "waiting_min", "partners"}
+    assert body["insights"]["rides"] == 42
+    assert body["insights"]["distance_km"] == pytest.approx(5312.44)
+    assert body["insights"]["waiting_min"] == 980
+
+    assert isinstance(body["rides"], list)
+    assert len(body["rides"]) <= RIDES_IN_MODAL_CAP
+    assert body["rides_total"] >= len(body["rides"])
+    # submission_sort_key is an internal sort artifact and must not leak to the client.
+    for ride in body["rides"]:
+        assert "submission_sort_key" not in ride
+
+
+def test_me_json_logged_in_is_still_not_publicly_cacheable(client, logged_in_user):
+    resp = client.get("/me.json")
+    assert "public" not in resp.headers.get("Cache-Control", "")
+    assert "no-store" in resp.headers.get("Cache-Control", "")

--- a/tests/test_oauth_popup.py
+++ b/tests/test_oauth_popup.py
@@ -60,3 +60,37 @@ def test_finish_login_popup_carries_needs_profile(app):
         session["oauth_popup"] = True
         html = _finish_login("/edit-user", needs_profile=True)
         assert "true" in html.split("needsProfile:")[1].split("\n")[0]
+
+
+def test_redirect_uri_defaults_to_request_origin(app):
+    """Unset HITCHWIKI_OAUTH_REDIRECT_BASE -> unchanged behaviour (url_for + scheme)."""
+    from hitch.blueprints.oauth import _redirect_uri
+
+    app.config["HITCHWIKI_OAUTH_REDIRECT_BASE"] = None
+    app.config["HITCHWIKI_OAUTH_REDIRECT_SCHEME"] = "http"
+    with app.test_request_context("/", base_url="http://127.0.0.1:5001"):
+        assert _redirect_uri() == "http://127.0.0.1:5001/login"
+
+
+def test_redirect_uri_can_be_pinned_to_a_tunnel_origin(app):
+    """A tunnel's hostname is never what url_for() would infer, so allow pinning it."""
+    from hitch.blueprints.oauth import _redirect_uri
+
+    app.config["HITCHWIKI_OAUTH_REDIRECT_BASE"] = "https://example.trycloudflare.com"
+    try:
+        # Request arrives on some other origin entirely; the pinned base still wins.
+        with app.test_request_context("/", base_url="http://localhost:5001"):
+            assert _redirect_uri() == "https://example.trycloudflare.com/login"
+    finally:
+        app.config["HITCHWIKI_OAUTH_REDIRECT_BASE"] = None
+
+
+def test_redirect_uri_base_tolerates_a_trailing_slash(app):
+    from hitch.blueprints.oauth import _redirect_uri
+
+    app.config["HITCHWIKI_OAUTH_REDIRECT_BASE"] = "https://example.trycloudflare.com/"
+    try:
+        with app.test_request_context("/", base_url="http://localhost:5001"):
+            assert _redirect_uri() == "https://example.trycloudflare.com/login"
+    finally:
+        app.config["HITCHWIKI_OAUTH_REDIRECT_BASE"] = None

--- a/tests/test_oauth_popup.py
+++ b/tests/test_oauth_popup.py
@@ -1,0 +1,62 @@
+"""The OAuth flow can complete in a popup, so the map page never unloads (issue #106)."""
+
+
+def test_popup_flag_is_set_and_state_still_stored(client):
+    resp = client.get("/login/oauth?popup=1")
+    # Still redirects out to Hitchwiki — the popup is what follows it.
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert sess["oauth_popup"] is True
+        assert sess["oauth_state"]
+
+
+def test_plain_login_oauth_sets_no_popup_flag(client):
+    client.get("/login/oauth")
+    with client.session_transaction() as sess:
+        assert "oauth_popup" not in sess
+
+
+def test_popup_flag_is_cleared_by_a_later_full_page_login(client):
+    """A stale flag must not turn a normal login into a popup-completion page."""
+    client.get("/login/oauth?popup=1")
+    client.get("/login/oauth")
+    with client.session_transaction() as sess:
+        assert "oauth_popup" not in sess
+
+
+def test_finish_login_renders_postmessage_page_for_popup(app):
+    """With the flag set, the flow ends in the closing page instead of a 302."""
+    from hitch.blueprints.oauth import _finish_login
+
+    with app.test_request_context("/login?code=abc"):
+        from flask import session
+
+        session["oauth_popup"] = True
+        resp = _finish_login("/me", needs_profile=False)
+        html = resp if isinstance(resp, str) else resp
+        assert "hitchwiki-auth" in html
+        # Never postMessage to a wildcard origin.
+        assert '"*"' not in html
+        assert "window.location.origin" in html
+        # The flag is single-use.
+        assert "oauth_popup" not in session
+
+
+def test_finish_login_redirects_when_not_a_popup(app):
+    from hitch.blueprints.oauth import _finish_login
+
+    with app.test_request_context("/login?code=abc"):
+        resp = _finish_login("/me", needs_profile=False)
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/me"
+
+
+def test_finish_login_popup_carries_needs_profile(app):
+    from hitch.blueprints.oauth import _finish_login
+
+    with app.test_request_context("/login?code=abc"):
+        from flask import session
+
+        session["oauth_popup"] = True
+        html = _finish_login("/edit-user", needs_profile=True)
+        assert "true" in html.split("needsProfile:")[1].split("\n")[0]


### PR DESCRIPTION
Closes #106.

## Why

The account button was a plain `<a href="/me">`. Tapping it unloaded the map:

- an in-progress **in-ride journey** lost its dock and open sheets
- **test mode** exited (we hit this while testing #101; the workaround was opening account links in a new tab — a band-aid)
- the **viewport, open spot pane, and planned route** were discarded
- returning meant a fresh map boot: re-downloading `spots.json` (4.2 MB) and `rides_index.json` (26.5 MB)

Leaving the map to read four numbers about yourself is the wrong trade for a map-first PWA.

## What

The avatar now opens a modal. The map page never unloads.

**Logged out** — a one-line pitch and **Log in with Hitchwiki**.
**Logged in** — username, four lifetime totals, the **10 most recent rides** (expandable), and **View full profile →** for everything else (trips, achievements, editing, followers all stay on the web profile).

## The login constraint

Login is **Hitchwiki OAuth2**, not a local password form: `/login/oauth` redirects to `hitchwiki.org/rest.php/oauth2/authorize`, and the callback hard-redirects to `/me` (or `/edit-user` for a new user) with no `next` support. **A modal cannot host the credential form.**

So the login completes in a **popup**:

```
avatar tap → modal (logged out)
    [ Log in with Hitchwiki ]
          ↓ window.open("/login/oauth?popup=1")
    popup: hitchwiki.org/authorize
          ↓ callback on OUR origin
    popup postMessages the opener, closes itself
    modal re-renders logged-in; map never unloaded
```

- `?popup=1` records the flag **in the session** — Hitchwiki redirects back with only `code` and `state`, so nothing else of ours survives the round trip.
- The callback then renders a closing page instead of navigating. **The non-popup flow is unchanged** (still 302 to `/me` / `/edit-user`), and a later full-page login clears any stale flag, so a normal login can never render the popup page.

### Security

- The popup page targets `window.location.origin` **explicitly, never a wildcard** — a test asserts the wildcard never appears in the rendered page.
- The opener trusts a message only when `event.origin === window.location.origin` **and** `event.source === popupHandle` **and** the payload type matches.
- The existing OAuth `state` CSRF check in `_handle_callback` is untouched.
- **`/me.json` is `Cache-Control: private, no-store`.** This is per-user data, and #105 just had to fix a bug where a `Set-Cookie` rode along on a `public` response. A test asserts this endpoint is never `public`.

### Fallbacks

- **Popup blocked** (routine on mobile Safari): `window.open` returns `null` → fall back to today's full-page `/login/oauth`. The in-ride journey lives in `localStorage`; the viewport is in the URL.
- **Browser refuses to close the popup:** it self-navigates to `/me` (or `/edit-user`) after a moment, so a brand-new account still reaches profile setup.
- **No JS / middle-click / ⌘-click:** the avatar is still an `<a href="/me">`; only an unmodified left click is intercepted.

## Data

`GET /me.json` — new, modelled on the existing `/user` JSON endpoint. No new aggregation; `total_rides` / `total_distance_km` / `total_waiting_time_min` are already precomputed on the `user` row by `show.py`, and `_distinct_partner_count()` / `_get_rides_for_user()` already exist.

- **Anonymous → `200 {"logged_in": false}`**, never a 302. `fetch()` would silently follow a redirect and hand the modal an HTML login page.
- Rides capped at 50; `rides_total` carries the untruncated count so the UI can say "Showing 50 of 231". The internal `submission_sort_key` is stripped.

## Notes

- The modal is a **peer** of the in-ride sheets and deliberately does **not** register with `journeyUI._openDialog` — that single-flight guard tears down a parent sheet when a second opens (the Critical bug in #102).
- `account.js` is a dual browser/CommonJS module like `ride_submit.js`, so the pure formatters are node-testable.

## Testing

- **pytest (31 passing):** `/me.json` anonymous → 200 + `logged_in: false`; logged-in payload shape, ride cap, `rides_total`, no `submission_sort_key` leak; `Cache-Control` never `public` in either state. Popup flag set/cleared; `_finish_login` renders the postMessage page with a non-wildcard origin and 302s when not a popup; `needs_profile` rides through.
- **node (6 passing):** insight formatting, hour/minute rollover, truncation summary, ride labels, and empty-payload tolerance.
- **ruff** clean.
- **Manual, still to do:** popup-blocked fallback on real mobile Safari, and confirming an in-ride journey + test mode survive opening/closing the modal.

Design: `docs/superpowers/specs/2026-07-10-account-modal-design.md` · Plan: `docs/superpowers/plans/2026-07-10-account-modal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)