### PR TITLE
Gamified nudge to complete past rides' data (#109)

### DIFF
--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -4,8 +4,9 @@
 # every 10 minutes
 */10 * * * * cd /app && /usr/bin/flock -n /tmp/show.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate show' > logs/show.log 2>&1
 
-# daily at 4:45 AM — reverse-geocode ride endpoints into dist/ride_places.json.
-# Offline (reverse_geocoder, ~150 MB transient) so the web workers never carry that cost.
+# daily at 4:45 AM — reverse-geocode new rides' endpoints into the ride_place table.
+# Incremental: steady-state runs geocode nothing, so reverse_geocoder never builds its
+# ~150 MB index. Offline by design — that cost must never live in the web workers.
 45 4 * * * cd /app && /usr/bin/flock -n /tmp/ride_places.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate ride_places' > logs/ride_places.log 2>&1
 # every day at 2 AM
 0 7 * * * cd /app && /usr/bin/flock -n /tmp/sync_upstream.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate sync_upstream' > logs/sync_upstream.log 2>&1

--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -3,6 +3,10 @@
 */30 * * * * cd /app && /usr/bin/flock -n /tmp/fetch_nostr.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate fetch_nostr' > logs/fetch_nostr.log 2>&1
 # every 10 minutes
 */10 * * * * cd /app && /usr/bin/flock -n /tmp/show.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate show' > logs/show.log 2>&1
+
+# daily at 4:45 AM — reverse-geocode ride endpoints into dist/ride_places.json.
+# Offline (reverse_geocoder, ~150 MB transient) so the web workers never carry that cost.
+45 4 * * * cd /app && /usr/bin/flock -n /tmp/ride_places.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate ride_places' > logs/ride_places.log 2>&1
 # every day at 2 AM
 0 7 * * * cd /app && /usr/bin/flock -n /tmp/sync_upstream.lockfile bash -c 'echo "=== $(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) ===" && /usr/local/bin/flask --app hitch generate sync_upstream' > logs/sync_upstream.log 2>&1
 # each day at midnight

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -96,6 +96,36 @@ def _ride_places(d_tags):
     return {row.d_tag: row for row in rows}
 
 
+def _ride_needs_detail(ride_info):
+    """Whether this ride is worth topping up: editable AND either incomplete or missing
+    its destination. Mirrors ridesNeedingDetails() in account.js so the avatar dot and the
+    modal's "N rides could use more detail" line never disagree.
+
+    Editable means type "own" — /ride?edit= only prefills rides we published, so an
+    imported or co-hitchhiker ride has no way to be improved and must not be counted.
+    """
+    if ride_info.get("type") != "own":
+        return False
+    return ride_info.get("completion", 0) < 100 or ride_info.get("missing_destination")
+
+
+@user_bp.route("/me/incomplete_rides.json", methods=["GET"])
+def incomplete_rides_json():
+    """How many of the user's rides still want more detail — for the avatar nudge dot.
+
+    Its own endpoint, not part of /me.json, because account.js calls it on every page
+    load (only when logged in) just to decide whether to light the dot, whereas /me.json
+    is fetched only when the modal opens. Anonymous callers get 0 rather than a redirect.
+    """
+    # Anonymous users have no rides to nudge about; skip the query entirely.
+    rides = [] if current_user.is_anonymous else _get_rides_for_user(current_user)
+    count = sum(1 for ride in rides if _ride_needs_detail(ride))
+    resp = jsonify({"count": count})
+    # Per-user, like /me.json — never let a shared cache serve one user's count to another.
+    resp.headers["Cache-Control"] = "private, no-store"
+    return resp
+
+
 @user_bp.route("/me.json", methods=["GET"])
 def me_json():
     """Account data for the on-map account modal (issue #106).

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -578,6 +578,11 @@ def _extract_ride_info(ride, ride_type):
     distance = _ride_distance_km(info)
     info["distance_km"] = round(distance, 1) if distance is not None else None
     info["completion"] = _ride_completion_pct(ride)
+    # A ride that never recorded where it ended is incomplete data the user can still fix,
+    # so the modal flags it. A `no_ride` record is a give-up: the hitchhiker was never
+    # picked up, so having no destination is correct there and must not be flagged.
+    gave_up = content.get("no_ride") is not None
+    info["missing_destination"] = destination_lat is None and not gave_up
     return info
 
 

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -78,6 +78,29 @@ def get_user():
 # user to the full profile rather than shipping an unbounded ride list to every opener.
 RIDES_IN_MODAL_CAP = 50
 
+# dist/ride_places.json, keyed by d_tag -> {"from": ..., "to": ...}. Written offline by
+# hitch/scripts/ride_places.py: reverse_geocoder costs ~150 MB resident, which we refuse
+# to carry in every web worker on this host just to print a city name.
+_ride_places_cache = {"mtime": None, "data": {}}
+
+
+def _ride_places():
+    """Place names for every ride, reloaded only when the generated file changes."""
+    path = os.path.join(get_dirs()["dist"], "ride_places.json")
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        # Not generated yet (fresh deploy, or cron hasn't run). Rides simply go unlabelled.
+        return {}
+    if _ride_places_cache["mtime"] != mtime:
+        try:
+            with open(path) as f:
+                _ride_places_cache["data"] = json.load(f)
+            _ride_places_cache["mtime"] = mtime
+        except (OSError, ValueError):
+            return _ride_places_cache["data"]
+    return _ride_places_cache["data"]
+
 
 @user_bp.route("/me.json", methods=["GET"])
 def me_json():
@@ -91,7 +114,14 @@ def me_json():
         resp = jsonify({"logged_in": False})
     else:
         rides = _get_rides_for_user(current_user)
-        shown = [{k: v for k, v in r.items() if k != "submission_sort_key"} for r in rides[:RIDES_IN_MODAL_CAP]]
+        places = _ride_places()
+        shown = []
+        for ride in rides[:RIDES_IN_MODAL_CAP]:
+            entry = {k: v for k, v in ride.items() if k != "submission_sort_key"}
+            place = places.get(entry.get("d_tag")) or {}
+            entry["from_place"] = place.get("from")
+            entry["to_place"] = place.get("to")
+            shown.append(entry)
 
         total_rides = current_user.total_rides or 0
         total_km = current_user.total_distance_km or 0

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -18,7 +18,7 @@ from hitch.blueprints.utils.ride_score import score_fields
 from hitch.extensions import db, security
 from hitch.forms import UserEditForm
 from hitch.helpers import get_db, get_dirs, haversine_np
-from hitch.models import CoHitchhiker, Follow, Notification, RideEvent, RideReport, Trip, TripRide, User
+from hitch.models import CoHitchhiker, Follow, Notification, RideEvent, RidePlace, RideReport, Trip, TripRide, User
 
 os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
 
@@ -78,28 +78,22 @@ def get_user():
 # user to the full profile rather than shipping an unbounded ride list to every opener.
 RIDES_IN_MODAL_CAP = 50
 
-# dist/ride_places.json, keyed by d_tag -> {"from": ..., "to": ...}. Written offline by
-# hitch/scripts/ride_places.py: reverse_geocoder costs ~150 MB resident, which we refuse
-# to carry in every web worker on this host just to print a city name.
-_ride_places_cache = {"mtime": None, "data": {}}
 
+def _ride_places(d_tags):
+    """Place names for the given rides, as {d_tag: RidePlace}.
 
-def _ride_places():
-    """Place names for every ride, reloaded only when the generated file changes."""
-    path = os.path.join(get_dirs()["dist"], "ride_places.json")
-    try:
-        mtime = os.path.getmtime(path)
-    except OSError:
-        # Not generated yet (fresh deploy, or cron hasn't run). Rides simply go unlabelled.
+    Looks up only the d_tags actually being rendered. An earlier version cached the whole
+    corpus as a JSON blob; at ~70 000 rides that is ~7 MB on disk and ~33 MB of parsed
+    dict resident in every waitress worker, to answer a question about 50 rides.
+
+    Rows are absent until hitch/scripts/ride_places.py has run for a ride, so callers must
+    treat a miss as "not geocoded yet" rather than an error.
+    """
+    tags = [t for t in d_tags if t]
+    if not tags:
         return {}
-    if _ride_places_cache["mtime"] != mtime:
-        try:
-            with open(path) as f:
-                _ride_places_cache["data"] = json.load(f)
-            _ride_places_cache["mtime"] = mtime
-        except (OSError, ValueError):
-            return _ride_places_cache["data"]
-    return _ride_places_cache["data"]
+    rows = RidePlace.query.filter(RidePlace.d_tag.in_(tags)).all()
+    return {row.d_tag: row for row in rows}
 
 
 @user_bp.route("/me.json", methods=["GET"])
@@ -114,16 +108,18 @@ def me_json():
         resp = jsonify({"logged_in": False})
     else:
         rides = _get_rides_for_user(current_user)
-        places = _ride_places()
+        visible = rides[:RIDES_IN_MODAL_CAP]
+        # One bounded lookup for exactly the rides we are about to render.
+        places = _ride_places([r.get("d_tag") for r in visible])
         shown = []
-        for ride in rides[:RIDES_IN_MODAL_CAP]:
+        for ride in visible:
             entry = {k: v for k, v in ride.items() if k != "submission_sort_key"}
-            place = places.get(entry.get("d_tag")) or {}
-            entry["from_place"] = place.get("from")
-            entry["to_place"] = place.get("to")
+            place = places.get(entry.get("d_tag"))
+            entry["from_place"] = place.from_place if place else None
+            entry["to_place"] = place.to_place if place else None
             # ISO alpha-2; the client renders it as a flag emoji.
-            entry["from_cc"] = place.get("from_cc")
-            entry["to_cc"] = place.get("to_cc")
+            entry["from_cc"] = place.from_cc if place else None
+            entry["to_cc"] = place.to_cc if place else None
             shown.append(entry)
 
         total_rides = current_user.total_rides or 0

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -623,8 +623,10 @@ def _extract_ride_info(ride, ride_type):
     info["completion"] = _ride_completion_pct(ride)
     # A ride that never recorded where it ended is incomplete data the user can still fix,
     # so the modal flags it. A `no_ride` record is a give-up: the hitchhiker was never
-    # picked up, so having no destination is correct there and must not be flagged.
+    # picked up, so having no destination is correct there and must not be flagged. The
+    # UI still labels it, just as a fact rather than a problem — hence both flags.
     gave_up = content.get("no_ride") is not None
+    info["gave_up"] = gave_up
     info["missing_destination"] = destination_lat is None and not gave_up
     return info
 

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -92,17 +92,31 @@ def me_json():
     else:
         rides = _get_rides_for_user(current_user)
         shown = [{k: v for k, v in r.items() if k != "submission_sort_key"} for r in rides[:RIDES_IN_MODAL_CAP]]
+
+        total_rides = current_user.total_rides or 0
+        total_km = current_user.total_distance_km or 0
+        partners = _distinct_partner_count(current_user.username)
+
+        # Same ladders the /insights page renders, but only the tiers actually earned:
+        # the modal celebrates what you have, and the full profile shows what's left.
+        earned = [
+            {"emoji": card["emoji"], "name": card["name"], "blurb": card["blurb"]}
+            for card in _achievements({"rides": total_rides, "distance": total_km, "partners": partners})
+            if card["earned"]
+        ]
+
         resp = jsonify(
             {
                 "logged_in": True,
                 "username": current_user.username,
                 "profile_url": "/me",
                 "insights": {
-                    "rides": current_user.total_rides or 0,
-                    "distance_km": current_user.total_distance_km or 0,
+                    "rides": total_rides,
+                    "distance_km": total_km,
                     "waiting_min": current_user.total_waiting_time_min or 0,
-                    "partners": _distinct_partner_count(current_user.username),
+                    "partners": partners,
                 },
+                "achievements": earned,
                 "rides": shown,
                 # Untruncated, so the UI can say "showing 50 of 231" and link to the profile.
                 "rides_total": len(rides),

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -14,6 +14,7 @@ from hitch.blueprints.utils.hitchhiking_data_standard_pydantic_model import Hitc
 from hitch.blueprints.utils.notifications import notify_new_follower
 from hitch.blueprints.utils.post_hitchhiking_ride_to_nostr import HitchhikingDataStandardToNostrPoster
 from hitch.blueprints.utils.report_ride import OWNER_DELETE_REASON
+from hitch.blueprints.utils.ride_score import score_fields
 from hitch.extensions import db, security
 from hitch.forms import UserEditForm
 from hitch.helpers import get_db, get_dirs, haversine_np
@@ -295,6 +296,33 @@ def _ride_wait_minutes(ride):
         return None
 
 
+def _ride_completion_pct(ride):
+    """How complete this ride's driver/vehicle detail is, 0-100.
+
+    Reuses the canonical weights (ride_score) rather than re-deriving a score, so the
+    number a user sees on their ride list is the same one the in-ride sheet's meters
+    showed while they logged it. The stored Nostr record uses the data-standard's shape
+    (an occupant with was_driver, and mode_of_transportation), so map it back onto the
+    scorer's field names. Age is scored on presence: we store year_of_birth, not an age.
+    """
+    content = ride.content or {}
+    occupants = content.get("occupants") or []
+    driver = next((o for o in occupants if o.get("was_driver")), {})
+    transport = content.get("mode_of_transportation") or {}
+
+    return score_fields(
+        {
+            "driver_reason_to_pick_up": driver.get("reasons_to_pick_up") or [],
+            "driver_gender": driver.get("gender") or "",
+            "driver_age": driver.get("year_of_birth") or "",
+            "driver_origin_country": driver.get("origin_country") or "",
+            "driver_languages": driver.get("languages") or [],
+            "vehicle_kind": transport.get("kind") or "",
+            "vehicle_license_plate_country": transport.get("license_plate_country") or "",
+        }
+    )["pct"]
+
+
 def _ride_distance_km(info):
     """Pickup→destination distance of a ride in km, or None when it has no destination.
 
@@ -531,7 +559,7 @@ def _extract_ride_info(ride, ride_type):
     submission_dt = pd.to_datetime(ride.submission_time, errors="coerce", utc=True) if ride.submission_time else None
     submission_display = submission_dt.strftime("%Y-%m-%d %H:%M") if submission_dt is not None and pd.notna(submission_dt) else ""
     submission_sort_key = submission_dt.value if submission_dt is not None and pd.notna(submission_dt) else None
-    return {
+    info = {
         "type": ride_type,
         "d_tag": ride.d,
         "created": submission_display,
@@ -543,6 +571,14 @@ def _extract_ride_info(ride, ride_type):
         "destination_lat": destination_lat,
         "destination_lon": destination_lon,
     }
+    # Surfaced by the account modal's ride list. None means "not recorded", and the UI
+    # omits the stat rather than printing a misleading zero. _ride_distance_km reads the
+    # coords off the info dict, so it has to run once the dict exists.
+    info["wait_min"] = _ride_wait_minutes(ride)
+    distance = _ride_distance_km(info)
+    info["distance_km"] = round(distance, 1) if distance is not None else None
+    info["completion"] = _ride_completion_pct(ride)
+    return info
 
 
 def _norm_nickname(s):

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -339,6 +339,29 @@ def _ride_wait_minutes(ride):
         return None
 
 
+def _ride_duration_minutes(ride):
+    """Time spent moving: the last stop's arrival minus the first stop's departure.
+
+    Distinct from the waiting time, which is time spent stopped at the roadside. Either
+    timestamp may be absent (the in-ride tracker records both; the historic form often
+    does not), and a clock skew could make arrival precede departure — in every such case
+    return None so the UI simply omits the figure rather than printing something wrong.
+    """
+    stops = (ride.content or {}).get("stops") or []
+    if len(stops) < 2:
+        return None
+    departure = stops[0].get("departure_time")
+    arrival = stops[-1].get("arrival_time")
+    if not departure or not arrival:
+        return None
+    start = pd.to_datetime(departure, errors="coerce", utc=True)
+    end = pd.to_datetime(arrival, errors="coerce", utc=True)
+    if pd.isna(start) or pd.isna(end):
+        return None
+    minutes = (end - start).total_seconds() / 60
+    return round(minutes) if minutes > 0 else None
+
+
 def _ride_completion_pct(ride):
     """How complete this ride's driver/vehicle detail is, 0-100.
 
@@ -618,6 +641,7 @@ def _extract_ride_info(ride, ride_type):
     # omits the stat rather than printing a misleading zero. _ride_distance_km reads the
     # coords off the info dict, so it has to run once the dict exists.
     info["wait_min"] = _ride_wait_minutes(ride)
+    info["ride_min"] = _ride_duration_minutes(ride)
     distance = _ride_distance_km(info)
     info["distance_km"] = round(distance, 1) if distance is not None else None
     info["completion"] = _ride_completion_pct(ride)

--- a/hitch/blueprints/user.py
+++ b/hitch/blueprints/user.py
@@ -121,6 +121,9 @@ def me_json():
             place = places.get(entry.get("d_tag")) or {}
             entry["from_place"] = place.get("from")
             entry["to_place"] = place.get("to")
+            # ISO alpha-2; the client renders it as a flag emoji.
+            entry["from_cc"] = place.get("from_cc")
+            entry["to_cc"] = place.get("to_cc")
             shown.append(entry)
 
         total_rides = current_user.total_rides or 0

--- a/hitch/models.py
+++ b/hitch/models.py
@@ -223,3 +223,23 @@ class HitchwikiArticleMap(db.Model):
     longitude = db.Column(db.Float, nullable=False)
     zoom = db.Column(db.Integer, nullable=False)
     hitchwiki_url = db.Column(db.String(255), nullable=False)
+
+
+class RidePlace(db.Model):
+    """Reverse-geocoded endpoint names for a ride, keyed by its Nostr `d` tag.
+
+    A separate table rather than columns on RideEvent because fetch_nostr deletes and
+    rebuilds ride_event wholesale every 30 minutes; place names must outlive that so the
+    geocoder only ever has to resolve rides it has not seen before.
+
+    Written offline by hitch/scripts/ride_places.py: reverse_geocoder costs ~150 MB
+    resident once its index builds, which must not live in the web workers on this host.
+    """
+
+    __tablename__ = "ride_place"
+
+    d_tag = db.Column(db.String(255), primary_key=True)
+    from_place = db.Column(db.String(255), nullable=True)
+    from_cc = db.Column(db.String(2), nullable=True)  # ISO 3166-1 alpha-2
+    to_place = db.Column(db.String(255), nullable=True)
+    to_cc = db.Column(db.String(2), nullable=True)

--- a/hitch/scripts/ride_places.py
+++ b/hitch/scripts/ride_places.py
@@ -2,7 +2,7 @@
 
 Writes dist/ride_places.json:
 
-    {"<d_tag>": {"from": "Metzeral", "to": "Mitte"}, ...}
+    {"<d_tag>": {"from": "Metzeral", "from_cc": "FR", "to": "Mitte", "to_cc": "DE"}, ...}
 
 Used by the account modal (issue #106) to label a ride "Metzeral → Mitte" instead of
 showing bare coordinates.
@@ -46,6 +46,11 @@ MIN_RIDE_DISTANCE_KM = 1
 def _label(hit):
     """Populated place, else administrative division, else country."""
     return (hit.get("name") or hit.get("admin1") or hit.get("cc") or "").strip() or None
+
+
+def _country(hit):
+    """ISO 3166-1 alpha-2, which the client turns into a flag emoji."""
+    return (hit.get("cc") or "").strip().upper() or None
 
 
 def _coords_from_stops(stops):
@@ -99,12 +104,17 @@ def main():
     for (d_tag, slot), hit in zip(slots, hits):
         label = _label(hit)
         if label:
-            places.setdefault(d_tag, {})[slot] = label
+            entry = places.setdefault(d_tag, {})
+            entry[slot] = label
+            country = _country(hit)
+            if country:
+                entry[slot + "_cc"] = country
 
     # "Berlin → Berlin" says nothing; drop the destination when it repeats the origin.
     for entry in places.values():
         if entry.get("to") and entry.get("to") == entry.get("from"):
             entry.pop("to")
+            entry.pop("to_cc", None)
 
     os.makedirs(DIST_DIR, exist_ok=True)
     with open(OUTPUT_JSON, "w") as f:

--- a/hitch/scripts/ride_places.py
+++ b/hitch/scripts/ride_places.py
@@ -1,24 +1,33 @@
-"""Reverse-geocode every ride's endpoints into place names, offline.
+"""Reverse-geocode ride endpoints into place names, offline and incrementally.
 
-Writes dist/ride_places.json:
+Fills the `ride_place` table: one row per ride `d` tag, holding the origin and
+destination place names plus their ISO country codes.
 
-    {"<d_tag>": {"from": "Metzeral", "from_cc": "FR", "to": "Mitte", "to_cc": "DE"}, ...}
+    d_tag | from_place | from_cc | to_place     | to_cc
+    ------+------------+---------+--------------+------
+    abc   | Metzeral   | FR      | Schweighofen | DE
 
-Used by the account modal (issue #106) to label a ride "Metzeral → Mitte" instead of
-showing bare coordinates.
+Consumed by the account modal (#106) and, via show.py, by every ride the map renders.
 
-Why a cron script rather than doing this in the request:
-`reverse_geocoder` costs ~150 MB resident once its index is built. Loading that into
-every waitress worker on a host the OOM killer has already visited (see CLAUDE.md) is
-not worth a place name. Here the cost is one transient process, and the app only ever
-reads a small JSON file — the same shape as show.py / country_ratings.py.
+Three decisions worth knowing:
 
+**Why a cron script, not a request.** `reverse_geocoder` costs ~150 MB resident once its
+index builds (measured). Loading that into every waitress worker on a host the OOM killer
+has already visited (CLAUDE.md) is not worth a city name. Here it is one transient
+process; queries are ~0.1 ms once warm, so the whole corpus resolves in a single batch.
+
+**Why its own table, not columns on ride_event.** fetch_nostr deletes and rebuilds
+ride_event wholesale every 30 minutes. Place names stored there would be destroyed twice
+an hour and re-geocoded from nothing.
+
+**Why not a JSON blob in dist/.** At ~70 000 rides that file is ~7 MB, and any process
+reading it holds ~33 MB of parsed dict. A table lets a request look up the handful of
+d_tags it actually needs.
+
+Only rides missing from the table are geocoded, so steady-state runs are nearly free.
 Names prefer the populated place (`name`), falling back to the administrative division
 (`admin1`, e.g. "Berlin", "Lombardy") and finally the country code, so a ride in the
 middle of nowhere still gets a meaningful label.
-
-Rides are geocoded in ONE batched rg.search call: the index build dominates, and a
-single query for 20 000 points costs about the same as a query for one.
 """
 
 import json
@@ -35,12 +44,16 @@ logger = logging.getLogger(__name__)
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 DATABASE_NAME = os.getenv("DATABASE_NAME", "hitchhiking-prod.sqlite")
 DATABASE_URI = os.getenv("DATABASE_URI", os.path.join(BASE_DIR, "db", DATABASE_NAME))
-DIST_DIR = os.path.join(BASE_DIR, "dist")
-OUTPUT_JSON = os.path.join(DIST_DIR, "ride_places.json")
 
-# Matches show.py / country_ratings.py: a "destination" closer than this is treated as
-# no destination at all, so we don't label a ride "Berlin → Berlin".
-MIN_RIDE_DISTANCE_KM = 1
+CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS ride_place (
+    d_tag      VARCHAR(255) PRIMARY KEY,
+    from_place VARCHAR(255),
+    from_cc    VARCHAR(2),
+    to_place   VARCHAR(255),
+    to_cc      VARCHAR(2)
+)
+"""
 
 
 def _label(hit):
@@ -71,13 +84,20 @@ def _coords_from_stops(stops):
 def main():
     conn = sqlite3.connect(DATABASE_URI)
     conn.row_factory = sqlite3.Row
+    conn.execute(CREATE_TABLE)
+    conn.commit()
+
+    known = {row[0] for row in conn.execute("SELECT d_tag FROM ride_place")}
     rows = conn.execute("SELECT d, content FROM ride_event WHERE d IS NOT NULL").fetchall()
-    conn.close()
 
     # Collect every point once, remembering which ride slot it belongs to, so the whole
-    # corpus resolves in a single query.
+    # backlog resolves in a single query. Rides already geocoded are skipped: a ride's
+    # coordinates never change (an edit republishes under the same d tag, and the map
+    # only ever gains rides), so a row once written stays correct.
     points, slots = [], []
     for row in rows:
+        if row["d"] in known:
+            continue
         try:
             content = json.loads(row["content"]) if isinstance(row["content"], str) else (row["content"] or {})
         except (TypeError, ValueError):
@@ -91,13 +111,11 @@ def main():
             slots.append((row["d"], "to"))
 
     if not points:
-        logger.info("No ride coordinates to geocode.")
-        os.makedirs(DIST_DIR, exist_ok=True)
-        with open(OUTPUT_JSON, "w") as f:
-            json.dump({}, f)
+        logger.info("Nothing new to geocode (%d rides already resolved).", len(known))
+        conn.close()
         return
 
-    logger.info("Reverse-geocoding %d points across %d rides", len(points), len(rows))
+    logger.info("Reverse-geocoding %d points for %d new rides", len(points), len({d for d, _ in slots}))
     hits = rg.search(points, mode=1, verbose=False)
 
     places = {}
@@ -116,10 +134,16 @@ def main():
             entry.pop("to")
             entry.pop("to_cc", None)
 
-    os.makedirs(DIST_DIR, exist_ok=True)
-    with open(OUTPUT_JSON, "w") as f:
-        json.dump(places, f)
-    logger.info("Wrote %s (%d rides)", OUTPUT_JSON, len(places))
+    conn.executemany(
+        "INSERT OR REPLACE INTO ride_place (d_tag, from_place, from_cc, to_place, to_cc) VALUES (?, ?, ?, ?, ?)",
+        [
+            (d_tag, e.get("from"), e.get("from_cc"), e.get("to"), e.get("to_cc"))
+            for d_tag, e in places.items()
+        ],
+    )
+    conn.commit()
+    logger.info("Wrote %d ride_place rows (%d total)", len(places), len(known) + len(places))
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/hitch/scripts/ride_places.py
+++ b/hitch/scripts/ride_places.py
@@ -1,0 +1,116 @@
+"""Reverse-geocode every ride's endpoints into place names, offline.
+
+Writes dist/ride_places.json:
+
+    {"<d_tag>": {"from": "Metzeral", "to": "Mitte"}, ...}
+
+Used by the account modal (issue #106) to label a ride "Metzeral → Mitte" instead of
+showing bare coordinates.
+
+Why a cron script rather than doing this in the request:
+`reverse_geocoder` costs ~150 MB resident once its index is built. Loading that into
+every waitress worker on a host the OOM killer has already visited (see CLAUDE.md) is
+not worth a place name. Here the cost is one transient process, and the app only ever
+reads a small JSON file — the same shape as show.py / country_ratings.py.
+
+Names prefer the populated place (`name`), falling back to the administrative division
+(`admin1`, e.g. "Berlin", "Lombardy") and finally the country code, so a ride in the
+middle of nowhere still gets a meaningful label.
+
+Rides are geocoded in ONE batched rg.search call: the index build dominates, and a
+single query for 20 000 points costs about the same as a query for one.
+"""
+
+import json
+import logging
+import os
+import sqlite3
+
+import reverse_geocoder as rg
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Resolve the DB path the same way hitch/settings.py does: db/{DATABASE_NAME}.
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DATABASE_NAME = os.getenv("DATABASE_NAME", "hitchhiking-prod.sqlite")
+DATABASE_URI = os.getenv("DATABASE_URI", os.path.join(BASE_DIR, "db", DATABASE_NAME))
+DIST_DIR = os.path.join(BASE_DIR, "dist")
+OUTPUT_JSON = os.path.join(DIST_DIR, "ride_places.json")
+
+# Matches show.py / country_ratings.py: a "destination" closer than this is treated as
+# no destination at all, so we don't label a ride "Berlin → Berlin".
+MIN_RIDE_DISTANCE_KM = 1
+
+
+def _label(hit):
+    """Populated place, else administrative division, else country."""
+    return (hit.get("name") or hit.get("admin1") or hit.get("cc") or "").strip() or None
+
+
+def _coords_from_stops(stops):
+    """(pickup, destination) as (lat, lon) pairs; destination is None when absent."""
+    if not stops:
+        return None, None
+
+    def point(stop):
+        loc = (stop or {}).get("location") or {}
+        lat, lon = loc.get("latitude"), loc.get("longitude")
+        return (float(lat), float(lon)) if lat is not None and lon is not None else None
+
+    pickup = point(stops[0])
+    destination = point(stops[-1]) if len(stops) > 1 else None
+    return pickup, destination
+
+
+def main():
+    conn = sqlite3.connect(DATABASE_URI)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT d, content FROM ride_event WHERE d IS NOT NULL").fetchall()
+    conn.close()
+
+    # Collect every point once, remembering which ride slot it belongs to, so the whole
+    # corpus resolves in a single query.
+    points, slots = [], []
+    for row in rows:
+        try:
+            content = json.loads(row["content"]) if isinstance(row["content"], str) else (row["content"] or {})
+        except (TypeError, ValueError):
+            continue
+        pickup, destination = _coords_from_stops(content.get("stops"))
+        if pickup:
+            points.append(pickup)
+            slots.append((row["d"], "from"))
+        if destination:
+            points.append(destination)
+            slots.append((row["d"], "to"))
+
+    if not points:
+        logger.info("No ride coordinates to geocode.")
+        os.makedirs(DIST_DIR, exist_ok=True)
+        with open(OUTPUT_JSON, "w") as f:
+            json.dump({}, f)
+        return
+
+    logger.info("Reverse-geocoding %d points across %d rides", len(points), len(rows))
+    hits = rg.search(points, mode=1, verbose=False)
+
+    places = {}
+    for (d_tag, slot), hit in zip(slots, hits):
+        label = _label(hit)
+        if label:
+            places.setdefault(d_tag, {})[slot] = label
+
+    # "Berlin → Berlin" says nothing; drop the destination when it repeats the origin.
+    for entry in places.values():
+        if entry.get("to") and entry.get("to") == entry.get("from"):
+            entry.pop("to")
+
+    os.makedirs(DIST_DIR, exist_ok=True)
+    with open(OUTPUT_JSON, "w") as f:
+        json.dump(places, f)
+    logger.info("Wrote %s (%d rides)", OUTPUT_JSON, len(places))
+
+
+if __name__ == "__main__":
+    main()

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -43,6 +43,24 @@
     return { when: when, stars: stars, comment: (ride.comment || "").trim() };
   }
 
+  // The three stats beside a ride's completion pie. A null means the ride never recorded
+  // that value, so it is omitted rather than shown as a misleading "0 min" / "0 km".
+  function rideStats(ride) {
+    const out = [];
+    const wait = ride.wait_min;
+    if (wait != null) {
+      out.push(wait >= 60 ? Math.floor(wait / 60) + " h " + (wait % 60) + " m" : wait + " min");
+    }
+    const km = ride.distance_km;
+    if (km != null) out.push(Math.round(km).toLocaleString("en-US") + " km");
+    return out;
+  }
+
+  function completionPct(ride) {
+    const pct = ride.completion;
+    return typeof pct === "number" ? Math.max(0, Math.min(100, Math.round(pct))) : 0;
+  }
+
   // ── DOM (browser only) ─────────────────────────────────────────────────────
 
   let _open = null; // { close }
@@ -163,10 +181,23 @@
     rides.forEach(function (ride, idx) {
       const li = el("li", "acct-ride");
       if (idx >= RIDES_SHOWN_COLLAPSED) li.classList.add("acct-ride--hidden");
-      const info = rideLabel(ride);
-      li.appendChild(el("span", "acct-ride__when", info.when));
-      if (info.stars) li.appendChild(el("span", "acct-ride__stars", info.stars));
-      if (info.comment) li.appendChild(el("span", "acct-ride__comment", info.comment));
+
+      // Completion pie: a conic-gradient sweep set from the ride's score. The number is
+      // the same one the in-ride sheet's meters showed, from the canonical weights.
+      const pct = completionPct(ride);
+      const pie = el("span", "acct-pie");
+      pie.style.setProperty("--pct", pct);
+      pie.setAttribute("role", "img");
+      pie.setAttribute("aria-label", pct + "% of driver and vehicle details recorded");
+      pie.title = pct + "% complete";
+      li.appendChild(pie);
+
+      const meta = el("div", "acct-ride__meta");
+      meta.appendChild(el("span", "acct-ride__when", rideLabel(ride).when));
+      const stats = rideStats(ride);
+      if (stats.length) meta.appendChild(el("span", "acct-ride__stats", stats.join(" · ")));
+      li.appendChild(meta);
+
       list.appendChild(li);
     });
     body.appendChild(list);
@@ -226,5 +257,13 @@
     else init();
   }
 
-  return { open: open, close: close, formatInsights: formatInsights, ridesSummary: ridesSummary, rideLabel: rideLabel };
+  return {
+    open: open,
+    close: close,
+    formatInsights: formatInsights,
+    ridesSummary: ridesSummary,
+    rideLabel: rideLabel,
+    rideStats: rideStats,
+    completionPct: completionPct,
+  };
 });

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -47,12 +47,60 @@
     return { when: when, stars: stars, comment: (ride.comment || "").trim() };
   }
 
-  // The stats beside a ride's completion pie. The date leads, then wait and distance.
+  const MONTHS = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ];
+
+  // "2026-07-28 12:00" -> "28 - July - 26 12:00". Parsed by hand rather than with Date():
+  // `created` is already the user's local submission time, and new Date("...") would
+  // re-interpret it against the browser's zone and shift the day.
+  function formatRideDate(created) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}))?/.exec(created || "");
+    if (!match) return "";
+    const month = MONTHS[Number(match[2]) - 1];
+    if (!month) return "";
+    const stamp = match[1].slice(2) + (match[4] ? " " + match[4] + ":" + match[5] : "");
+    return Number(match[3]) + " - " + month + " - " + stamp;
+  }
+
+  // What identifies a ride in the list. Place names when we have them; otherwise the
+  // date, which is the only other thing that distinguishes one ride from another.
+  function rideTitle(ride) {
+    return rideRoute(ride) || formatRideDate(ride.created) || "Unknown ride";
+  }
+
+  // The route split into its two ends, so the row can render the destination as a real
+  // element rather than a string: a missing destination is a clickable warning, and a
+  // give-up is a plain statement of fact, not an error.
+  //
+  //   endKind "place"   -> the destination is known
+  //           "missing" -> a real ride that never recorded where it ended (fixable)
+  //           "gaveup"  -> never picked up; having no destination is correct
+  //           null      -> nothing to say (e.g. destination unknown AND unlabelled origin)
+  function routeSegments(ride) {
+    const from = (ride.from_place || "").trim();
+    const fromFlag = flagEmoji(ride.from_cc);
+    const to = (ride.to_place || "").trim();
+    const toFlag = flagEmoji(ride.to_cc);
+
+    // With no origin name the date carries the row, and the arrow would dangle.
+    const start = from ? (fromFlag ? fromFlag + " " + from : from) : formatRideDate(ride.created) || "Unknown ride";
+
+    if (to) return { start: start, end: toFlag ? toFlag + " " + to : to, endKind: "place" };
+    if (ride.gave_up) return { start: start, end: "gave up", endKind: "gaveup" };
+    if (ride.missing_destination) return { start: start, end: "", endKind: "missing" };
+    return { start: start, end: "", endKind: null };
+  }
+
+  // The stats beside a ride's completion pie. The date leads, then wait and distance —
+  // unless the date is already serving as the ride's title, in which case repeating it
+  // would just be noise.
   // A null wait/distance means the ride never recorded it, so it is omitted rather than
   // shown as a misleading "0 min" / "0 km"; a real zero still renders.
-  function rideStats(ride) {
+  function rideStats(ride, includeDate) {
     const out = [];
-    const when = (ride.created || "").slice(0, 10);
+    const when = includeDate === false ? "" : (ride.created || "").slice(0, 10);
     if (when) out.push(when);
     const wait = ride.wait_min;
     if (wait != null) {
@@ -76,9 +124,9 @@
   }
 
   // A ride is identified by where it went, not when it happened. Place names come from
-  // dist/ride_places.json (offline reverse geocoding); they are absent until that cron
-  // has run, and for a give-up there is no destination — so fall back gracefully rather
-  // than printing "undefined → undefined".
+  // the ride_place table (offline reverse geocoding); they are absent until that cron has
+  // run for the ride, and a give-up has no destination — so return "" rather than
+  // printing "undefined → undefined", and let rideTitle fall back to the date.
   function rideRoute(ride) {
     const from = (ride.from_place || "").trim();
     const to = (ride.to_place || "").trim();
@@ -128,6 +176,14 @@
   function rideEditUrl(ride) {
     if (ride.type !== "own" || !ride.d_tag) return null;
     return "/ride?edit=" + encodeURIComponent(ride.d_tag);
+  }
+
+  // The read-only detail page for a ride. Public (main.ride_detail), so unlike editing
+  // this works for every ride the list can show — imported ones and co-hitchhiker rides
+  // included. A fully-logged ride has no CTA of its own; the row itself is the way in.
+  function rideViewUrl(ride) {
+    if (!ride.d_tag) return null;
+    return "/ride/" + encodeURIComponent(ride.d_tag);
   }
 
   // ── DOM (browser only) ─────────────────────────────────────────────────────
@@ -273,6 +329,26 @@
       const li = el("li", "acct-ride");
       if (idx >= RIDES_SHOWN_COLLAPSED) li.classList.add("acct-ride--hidden");
 
+      // Every ride opens its read-only detail page — including complete ones, which have
+      // no pie CTA of their own. New tab, so the map underneath is never unloaded.
+      const viewUrl = rideViewUrl(ride);
+      if (viewUrl) {
+        li.classList.add("acct-ride--clickable");
+        li.tabIndex = 0;
+        li.setAttribute("role", "link");
+        li.setAttribute("aria-label", "View ride details");
+        const openView = function () { window.open(viewUrl, "_blank", "noopener"); };
+        li.addEventListener("click", function (e) {
+          // The pie and the warning are their own links to the edit form; a click on one
+          // must not also open the detail page behind it.
+          if (e.target.closest("a")) return;
+          openView();
+        });
+        li.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openView(); }
+        });
+      }
+
       // Completion pie: a conic-gradient sweep set from the ride's score. The number is
       // the same one the in-ride sheet's meters showed, from the canonical weights.
       // Below 100% it becomes a CTA to go fill in what's missing.
@@ -314,18 +390,25 @@
       li.appendChild(pie);
 
       const meta = el("div", "acct-ride__meta");
-      // Where it went is the ride's identity; the date is now one of the small details.
-      const route = rideRoute(ride);
-      meta.appendChild(el("span", "acct-ride__route", route || "Unknown route"));
-      if (!route) meta.firstChild.classList.add("acct-ride__route--unknown");
-      const stats = rideStats(ride);
-      if (stats.length) meta.appendChild(el("span", "acct-ride__stats", stats.join(" · ")));
-      li.appendChild(meta);
 
-      // The ride never recorded where it ended — data the user can still fix. Give-ups
-      // are excluded server-side, so this never fires on a ride that legitimately has
-      // no destination. Editable rides get a link straight to the fix.
-      if (ride.missing_destination) {
+      // Where it went is the ride's identity. The destination is a real element, not a
+      // string, so a missing one can be a clickable warning inline in the route: the
+      // arrow already promises a destination, and this is what sits where it should be.
+      const seg = routeSegments(ride);
+      const hasPlaces = Boolean((ride.from_place || "").trim());
+      const routeEl = el("span", "acct-ride__route");
+      if (!hasPlaces) routeEl.classList.add("acct-ride__route--fallback");
+      routeEl.appendChild(el("span", null, seg.start));
+
+      if (seg.endKind === "place") {
+        routeEl.appendChild(el("span", "acct-ride__arrow", " → "));
+        routeEl.appendChild(el("span", null, seg.end));
+      } else if (seg.endKind === "gaveup") {
+        // Not an error: the hitchhiker was never picked up, so there is no destination.
+        routeEl.appendChild(el("span", "acct-ride__arrow", " → "));
+        routeEl.appendChild(el("span", "acct-ride__gaveup", seg.end));
+      } else if (seg.endKind === "missing") {
+        routeEl.appendChild(el("span", "acct-ride__arrow", " → "));
         const warn = el(editUrl ? "a" : "span", "acct-ride__warn");
         warn.innerHTML = '<i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>';
         if (editUrl) {
@@ -339,8 +422,14 @@
           warn.setAttribute("role", "img");
           warn.setAttribute("aria-label", "No destination recorded for this ride");
         }
-        li.appendChild(warn);
+        routeEl.appendChild(warn);
       }
+      meta.appendChild(routeEl);
+
+      // The date only appears below when it is not already carrying the row above.
+      const stats = rideStats(ride, hasPlaces);
+      if (stats.length) meta.appendChild(el("span", "acct-ride__stats", stats.join(" · ")));
+      li.appendChild(meta);
 
       list.appendChild(li);
     });
@@ -416,5 +505,9 @@
     nudgeText: nudgeText,
     rideRoute: rideRoute,
     flagEmoji: flagEmoji,
+    formatRideDate: formatRideDate,
+    rideTitle: rideTitle,
+    routeSegments: routeSegments,
+    rideViewUrl: rideViewUrl,
   };
 });

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -47,10 +47,13 @@
     return { when: when, stars: stars, comment: (ride.comment || "").trim() };
   }
 
-  // The three stats beside a ride's completion pie. A null means the ride never recorded
-  // that value, so it is omitted rather than shown as a misleading "0 min" / "0 km".
+  // The stats beside a ride's completion pie. The date leads, then wait and distance.
+  // A null wait/distance means the ride never recorded it, so it is omitted rather than
+  // shown as a misleading "0 min" / "0 km"; a real zero still renders.
   function rideStats(ride) {
     const out = [];
+    const when = (ride.created || "").slice(0, 10);
+    if (when) out.push(when);
     const wait = ride.wait_min;
     if (wait != null) {
       out.push(wait >= 60 ? Math.floor(wait / 60) + " h " + (wait % 60) + " m" : wait + " min");
@@ -58,6 +61,19 @@
     const km = ride.distance_km;
     if (km != null) out.push(Math.round(km).toLocaleString("en-US") + " km");
     return out;
+  }
+
+  // A ride is identified by where it went, not when it happened. Place names come from
+  // dist/ride_places.json (offline reverse geocoding); they are absent until that cron
+  // has run, and for a give-up there is no destination — so fall back gracefully rather
+  // than printing "undefined → undefined".
+  function rideRoute(ride) {
+    const from = (ride.from_place || "").trim();
+    const to = (ride.to_place || "").trim();
+    if (from && to) return from + " → " + to;
+    if (from) return from;
+    if (to) return "→ " + to;
+    return "";
   }
 
   function completionPct(ride) {
@@ -278,7 +294,10 @@
       li.appendChild(pie);
 
       const meta = el("div", "acct-ride__meta");
-      meta.appendChild(el("span", "acct-ride__when", rideLabel(ride).when));
+      // Where it went is the ride's identity; the date is now one of the small details.
+      const route = rideRoute(ride);
+      meta.appendChild(el("span", "acct-ride__route", route || "Unknown route"));
+      if (!route) meta.firstChild.classList.add("acct-ride__route--unknown");
       const stats = rideStats(ride);
       if (stats.length) meta.appendChild(el("span", "acct-ride__stats", stats.join(" · ")));
       li.appendChild(meta);
@@ -375,5 +394,6 @@
     completionTier: completionTier,
     ridesNeedingDetails: ridesNeedingDetails,
     nudgeText: nudgeText,
+    rideRoute: rideRoute,
   };
 });

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -491,6 +491,35 @@
     window.addEventListener("message", onMsg);
   }
 
+  // Light an amber dot on the avatar when the user has rides worth completing — the
+  // mirror of the red "log in" dot shown to anonymous visitors. Computed client-side,
+  // and only when logged in, so the map's render path and every anonymous load stay
+  // untouched; the count query only runs for the users it can apply to.
+  function refreshNudgeDot(link) {
+    if (typeof window === "undefined" || !window.IS_LOGGED_IN) return;
+    const btn = document.getElementById("top-account-btn");
+    if (!btn) return;
+    fetch("/me/incomplete_rides.json", { credentials: "same-origin" })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        const existing = btn.querySelector(".account-dot--amber");
+        // Don't fight the notification bell: unread notifications already own the corner.
+        if (data && data.count > 0 && !btn.querySelector(".notif-bell") && !existing) {
+          const dot = document.createElement("span");
+          dot.className = "account-dot account-dot--amber";
+          dot.setAttribute("role", "img");
+          dot.setAttribute(
+            "aria-label",
+            data.count === 1 ? "1 ride could use more detail" : data.count + " rides could use more detail"
+          );
+          link.appendChild(dot);
+        } else if ((!data || data.count === 0) && existing) {
+          existing.remove();
+        }
+      })
+      .catch(function () {}); // a nudge dot is not worth surfacing an error over
+  }
+
   function init() {
     const link = document.querySelector("#top-account-btn a");
     if (!link) return;
@@ -500,6 +529,7 @@
       e.preventDefault();
       open();
     });
+    refreshNudgeDot(link);
   }
 
   if (typeof document !== "undefined") {

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -65,6 +65,29 @@
     return typeof pct === "number" ? Math.max(0, Math.min(100, Math.round(pct))) : 0;
   }
 
+  // Completeness reads as a colour before it reads as a number: red is "barely logged",
+  // green is done. The tiers are what drive both the pie's colour and its animation, so
+  // they live here rather than being re-derived in CSS.
+  function completionTier(pct) {
+    if (pct >= 100) return "done";
+    if (pct >= 67) return "high";
+    if (pct >= 34) return "mid";
+    return "low";
+  }
+
+  // How many rides are still worth topping up. Drives the nudge line above the list —
+  // a concrete count is a stronger pull than a vague "add more detail".
+  function ridesNeedingDetails(rides) {
+    return (rides || []).filter(function (r) {
+      return rideEditUrl(r) && (completionPct(r) < 100 || r.missing_destination);
+    }).length;
+  }
+
+  function nudgeText(n) {
+    if (n === 0) return "Every ride is fully logged. Nice.";
+    return n === 1 ? "1 ride could use more detail" : n + " rides could use more detail";
+  }
+
   // Where a ride's "fix this" CTAs point, or null when the ride isn't editable.
   // /ride?edit=<d_tag> only prefills when _user_owns_ride passes, which requires the ride
   // to have been published by us — that is exactly type "own". A ride imported from
@@ -207,6 +230,12 @@
     const rides = data.rides || [];
     body.appendChild(el("div", "acct-rides-head", ridesSummary(rides.length, data.rides_total || rides.length)));
 
+    // A concrete count of what's left to fill in, or a small reward when nothing is.
+    const todo = ridesNeedingDetails(rides);
+    const nudge = el("div", "acct-nudge-line" + (todo === 0 ? " acct-nudge-line--done" : ""));
+    nudge.textContent = (todo === 0 ? "\u2728 " : "") + nudgeText(todo);
+    body.appendChild(nudge);
+
     const list = el("ul", "acct-rides");
     rides.forEach(function (ride, idx) {
       const li = el("li", "acct-ride");
@@ -216,22 +245,35 @@
       // the same one the in-ride sheet's meters showed, from the canonical weights.
       // Below 100% it becomes a CTA to go fill in what's missing.
       const pct = completionPct(ride);
+      const tier = completionTier(pct);
       const editUrl = rideEditUrl(ride);
-      const wantsDetails = editUrl && pct < 100;
-      const pie = el(wantsDetails ? "a" : "span", "acct-pie" + (wantsDetails ? " acct-pie--cta" : ""));
-      pie.style.setProperty("--pct", pct);
-      if (wantsDetails) {
-        // New tab: this modal exists so the map never unloads. Same reason the bottom-nav
-        // links open out-of-page. rel=noopener because target=_blank hands over window.opener.
-        pie.href = editUrl;
-        pie.target = "_blank";
-        pie.rel = "noopener";
-        pie.title = pct + "% complete — add driver and vehicle details";
-        pie.setAttribute("aria-label", "Ride " + pct + "% complete. Add driver and vehicle details.");
-      } else {
+
+      let pie;
+      if (tier === "done") {
+        // A finished ride stops being a progress bar and becomes a reward: the pie is
+        // replaced by a badge, so completing the last field visibly changes the thing.
+        pie = el("span", "acct-pie acct-pie--done");
+        pie.innerHTML = '<i class="fa-solid fa-circle-check" aria-hidden="true"></i>';
         pie.setAttribute("role", "img");
-        pie.setAttribute("aria-label", pct + "% of driver and vehicle details recorded");
-        pie.title = pct + "% complete";
+        pie.setAttribute("aria-label", "Ride fully logged");
+        pie.title = "Fully logged — nice one!";
+      } else {
+        const cta = Boolean(editUrl);
+        pie = el(cta ? "a" : "span", "acct-pie acct-pie--" + tier + (cta ? " acct-pie--cta" : ""));
+        pie.style.setProperty("--pct", pct);
+        if (cta) {
+          // New tab: this modal exists so the map never unloads. rel=noopener because
+          // target=_blank otherwise hands the new page a window.opener reference.
+          pie.href = editUrl;
+          pie.target = "_blank";
+          pie.rel = "noopener";
+          pie.title = pct + "% complete — add driver and vehicle details";
+          pie.setAttribute("aria-label", "Ride " + pct + "% complete. Add driver and vehicle details.");
+        } else {
+          pie.setAttribute("role", "img");
+          pie.setAttribute("aria-label", pct + "% of driver and vehicle details recorded");
+          pie.title = pct + "% complete";
+        }
       }
       li.appendChild(pie);
 
@@ -330,5 +372,8 @@
     completionPct: completionPct,
     rideEditUrl: rideEditUrl,
     awardsSummary: awardsSummary,
+    completionTier: completionTier,
+    ridesNeedingDetails: ridesNeedingDetails,
+    nudgeText: nudgeText,
   };
 });

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -491,8 +491,15 @@
     window.addEventListener("message", onMsg);
   }
 
-  // Light an amber dot on the avatar when the user has rides worth completing — the
-  // mirror of the red "log in" dot shown to anonymous visitors. Computed client-side,
+  // Badge text for a count: the number itself, capped at "99+" so a big backlog never
+  // blows out the badge width. Below 1 there is nothing to show.
+  function badgeCount(n) {
+    if (!(n > 0)) return "";
+    return n > 99 ? "99+" : String(n);
+  }
+
+  // Light an amber badge on the avatar carrying the number of rides worth completing —
+  // the mirror of the red "log in" dot shown to anonymous visitors. Computed client-side,
   // and only when logged in, so the map's render path and every anonymous load stay
   // untouched; the count query only runs for the users it can apply to.
   function refreshNudgeDot(link) {
@@ -503,17 +510,19 @@
       .then(function (r) { return r.json(); })
       .then(function (data) {
         const existing = btn.querySelector(".account-dot--amber");
+        const count = data ? data.count : 0;
         // Don't fight the notification bell: unread notifications already own the corner.
-        if (data && data.count > 0 && !btn.querySelector(".notif-bell") && !existing) {
+        if (count > 0 && !btn.querySelector(".notif-bell") && !existing) {
           const dot = document.createElement("span");
           dot.className = "account-dot account-dot--amber";
+          dot.textContent = badgeCount(count);
           dot.setAttribute("role", "img");
           dot.setAttribute(
             "aria-label",
-            data.count === 1 ? "1 ride could use more detail" : data.count + " rides could use more detail"
+            count === 1 ? "1 ride could use more detail" : count + " rides could use more detail"
           );
           link.appendChild(dot);
-        } else if ((!data || data.count === 0) && existing) {
+        } else if (count === 0 && existing) {
           existing.remove();
         }
       })
@@ -545,6 +554,7 @@
     rideLabel: rideLabel,
     rideStats: rideStats,
     completionPct: completionPct,
+    badgeCount: badgeCount,
     rideEditUrl: rideEditUrl,
     awardsSummary: awardsSummary,
     completionTier: completionTier,

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -93,21 +93,26 @@
     return { start: start, end: "", endKind: null };
   }
 
-  // The stats beside a ride's completion pie. The date leads, then wait and distance —
-  // unless the date is already serving as the ride's title, in which case repeating it
+  function durationText(mins) {
+    return mins >= 60 ? Math.floor(mins / 60) + " h " + (mins % 60) + " m" : mins + " min";
+  }
+
+  // The stats beside a ride's completion pie, as {text, dot} entries so the row can draw
+  // real dots: red for time stopped at the roadside, green for time actually moving.
+  // The date leads, unless it is already serving as the ride's title — repeating it there
   // would just be noise.
-  // A null wait/distance means the ride never recorded it, so it is omitted rather than
-  // shown as a misleading "0 min" / "0 km"; a real zero still renders.
+  //
+  // Anything the ride never recorded is silently omitted rather than shown as a
+  // misleading "0 min" / "0 km". A real zero is data, though, and still renders.
   function rideStats(ride, includeDate) {
     const out = [];
     const when = includeDate === false ? "" : (ride.created || "").slice(0, 10);
-    if (when) out.push(when);
-    const wait = ride.wait_min;
-    if (wait != null) {
-      out.push(wait >= 60 ? Math.floor(wait / 60) + " h " + (wait % 60) + " m" : wait + " min");
+    if (when) out.push({ text: when, dot: null });
+    if (ride.wait_min != null) out.push({ text: durationText(ride.wait_min), dot: "stopped" });
+    if (ride.ride_min != null) out.push({ text: durationText(ride.ride_min), dot: "going" });
+    if (ride.distance_km != null) {
+      out.push({ text: Math.round(ride.distance_km).toLocaleString("en-US") + " km", dot: null });
     }
-    const km = ride.distance_km;
-    if (km != null) out.push(Math.round(km).toLocaleString("en-US") + " km");
     return out;
   }
 
@@ -428,7 +433,19 @@
 
       // The date only appears below when it is not already carrying the row above.
       const stats = rideStats(ride, hasPlaces);
-      if (stats.length) meta.appendChild(el("span", "acct-ride__stats", stats.join(" · ")));
+      if (stats.length) {
+        const statsEl = el("span", "acct-ride__stats");
+        stats.forEach(function (stat, i) {
+          if (i) statsEl.appendChild(el("span", "acct-ride__sep", " · "));
+          if (stat.dot) {
+            const dot = el("span", "acct-dot acct-dot--" + stat.dot);
+            dot.title = stat.dot === "stopped" ? "Waiting at the roadside" : "Moving";
+            statsEl.appendChild(dot);
+          }
+          statsEl.appendChild(el("span", null, stat.text));
+        });
+        meta.appendChild(statsEl);
+      }
       li.appendChild(meta);
 
       list.appendChild(li);

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -198,6 +198,18 @@
       if (stats.length) meta.appendChild(el("span", "acct-ride__stats", stats.join(" · ")));
       li.appendChild(meta);
 
+      // The ride never recorded where it ended — data the user can still fix. Give-ups
+      // are excluded server-side, so this never fires on a ride that legitimately has
+      // no destination.
+      if (ride.missing_destination) {
+        const warn = el("span", "acct-ride__warn");
+        warn.innerHTML = '<i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>';
+        warn.title = "No destination recorded for this ride";
+        warn.setAttribute("role", "img");
+        warn.setAttribute("aria-label", "No destination recorded for this ride");
+        li.appendChild(warn);
+      }
+
       list.appendChild(li);
     });
     body.appendChild(list);

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -37,6 +37,10 @@
     return total + (total === 1 ? " ride" : " rides");
   }
 
+  function awardsSummary(n) {
+    return n + (n === 1 ? " award earned" : " awards earned");
+  }
+
   function rideLabel(ride) {
     const when = (ride.created || "").slice(0, 10);
     const stars = ride.rating ? "★".repeat(ride.rating) : "";
@@ -59,6 +63,16 @@
   function completionPct(ride) {
     const pct = ride.completion;
     return typeof pct === "number" ? Math.max(0, Math.min(100, Math.round(pct))) : 0;
+  }
+
+  // Where a ride's "fix this" CTAs point, or null when the ride isn't editable.
+  // /ride?edit=<d_tag> only prefills when _user_owns_ride passes, which requires the ride
+  // to have been published by us — that is exactly type "own". A ride imported from
+  // another source ("own_external") or awaiting co-hitchhiker acceptance can't be edited,
+  // so it gets a plain indicator instead of a dead link.
+  function rideEditUrl(ride) {
+    if (ride.type !== "own" || !ride.d_tag) return null;
+    return "/ride?edit=" + encodeURIComponent(ride.d_tag);
   }
 
   // ── DOM (browser only) ─────────────────────────────────────────────────────
@@ -174,6 +188,22 @@
     });
     body.appendChild(stats);
 
+    // Awards earned. Locked tiers stay on the full /insights page — the modal celebrates
+    // what you have rather than nagging about what you don't.
+    const awards = data.achievements || [];
+    if (awards.length) {
+      body.appendChild(el("div", "acct-rides-head", awardsSummary(awards.length)));
+      const wrap = el("div", "acct-awards");
+      awards.forEach(function (award) {
+        const chip = el("span", "acct-award");
+        chip.title = award.blurb || award.name;
+        chip.appendChild(el("span", "acct-award__emoji", award.emoji));
+        chip.appendChild(el("span", "acct-award__name", award.name));
+        wrap.appendChild(chip);
+      });
+      body.appendChild(wrap);
+    }
+
     const rides = data.rides || [];
     body.appendChild(el("div", "acct-rides-head", ridesSummary(rides.length, data.rides_total || rides.length)));
 
@@ -184,12 +214,25 @@
 
       // Completion pie: a conic-gradient sweep set from the ride's score. The number is
       // the same one the in-ride sheet's meters showed, from the canonical weights.
+      // Below 100% it becomes a CTA to go fill in what's missing.
       const pct = completionPct(ride);
-      const pie = el("span", "acct-pie");
+      const editUrl = rideEditUrl(ride);
+      const wantsDetails = editUrl && pct < 100;
+      const pie = el(wantsDetails ? "a" : "span", "acct-pie" + (wantsDetails ? " acct-pie--cta" : ""));
       pie.style.setProperty("--pct", pct);
-      pie.setAttribute("role", "img");
-      pie.setAttribute("aria-label", pct + "% of driver and vehicle details recorded");
-      pie.title = pct + "% complete";
+      if (wantsDetails) {
+        // New tab: this modal exists so the map never unloads. Same reason the bottom-nav
+        // links open out-of-page. rel=noopener because target=_blank hands over window.opener.
+        pie.href = editUrl;
+        pie.target = "_blank";
+        pie.rel = "noopener";
+        pie.title = pct + "% complete — add driver and vehicle details";
+        pie.setAttribute("aria-label", "Ride " + pct + "% complete. Add driver and vehicle details.");
+      } else {
+        pie.setAttribute("role", "img");
+        pie.setAttribute("aria-label", pct + "% of driver and vehicle details recorded");
+        pie.title = pct + "% complete";
+      }
       li.appendChild(pie);
 
       const meta = el("div", "acct-ride__meta");
@@ -200,13 +243,21 @@
 
       // The ride never recorded where it ended — data the user can still fix. Give-ups
       // are excluded server-side, so this never fires on a ride that legitimately has
-      // no destination.
+      // no destination. Editable rides get a link straight to the fix.
       if (ride.missing_destination) {
-        const warn = el("span", "acct-ride__warn");
+        const warn = el(editUrl ? "a" : "span", "acct-ride__warn");
         warn.innerHTML = '<i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>';
-        warn.title = "No destination recorded for this ride";
-        warn.setAttribute("role", "img");
-        warn.setAttribute("aria-label", "No destination recorded for this ride");
+        if (editUrl) {
+          warn.href = editUrl;
+          warn.target = "_blank";
+          warn.rel = "noopener";
+          warn.title = "No destination recorded — add it";
+          warn.setAttribute("aria-label", "No destination recorded for this ride. Add it.");
+        } else {
+          warn.title = "No destination recorded for this ride";
+          warn.setAttribute("role", "img");
+          warn.setAttribute("aria-label", "No destination recorded for this ride");
+        }
         li.appendChild(warn);
       }
 
@@ -277,5 +328,7 @@
     rideLabel: rideLabel,
     rideStats: rideStats,
     completionPct: completionPct,
+    rideEditUrl: rideEditUrl,
+    awardsSummary: awardsSummary,
   };
 });

--- a/hitch/static/account.js
+++ b/hitch/static/account.js
@@ -63,6 +63,18 @@
     return out;
   }
 
+  // An ISO 3166-1 alpha-2 code as a flag emoji: the two letters map onto the regional
+  // indicator symbols (U+1F1E6 is "A"). Anything that isn't two ASCII letters yields ""
+  // rather than a pair of stray glyphs.
+  function flagEmoji(cc) {
+    const code = (cc || "").trim().toUpperCase();
+    if (!/^[A-Z]{2}$/.test(code)) return "";
+    return String.fromCodePoint(
+      0x1f1e6 + code.charCodeAt(0) - 65,
+      0x1f1e6 + code.charCodeAt(1) - 65
+    );
+  }
+
   // A ride is identified by where it went, not when it happened. Place names come from
   // dist/ride_places.json (offline reverse geocoding); they are absent until that cron
   // has run, and for a give-up there is no destination — so fall back gracefully rather
@@ -70,9 +82,13 @@
   function rideRoute(ride) {
     const from = (ride.from_place || "").trim();
     const to = (ride.to_place || "").trim();
-    if (from && to) return from + " → " + to;
-    if (from) return from;
-    if (to) return "→ " + to;
+    const fromFlag = flagEmoji(ride.from_cc);
+    const toFlag = flagEmoji(ride.to_cc);
+    const start = from && (fromFlag ? fromFlag + " " + from : from);
+    const end = to && (toFlag ? toFlag + " " + to : to);
+    if (start && end) return start + " → " + end;
+    if (start) return start;
+    if (end) return "→ " + end;
     return "";
   }
 
@@ -267,9 +283,13 @@
       let pie;
       if (tier === "done") {
         // A finished ride stops being a progress bar and becomes a reward: the pie is
-        // replaced by a badge, so completing the last field visibly changes the thing.
+        // replaced by an award ribbon, so completing the last field visibly changes the
+        // thing. The rosette is its own element because the ribbon tails are drawn with
+        // the parent's ::before, and the sheen needs a second layer inside the disc.
         pie = el("span", "acct-pie acct-pie--done");
-        pie.innerHTML = '<i class="fa-solid fa-circle-check" aria-hidden="true"></i>';
+        const rosette = el("span", "acct-rosette");
+        rosette.innerHTML = '<i class="fa-solid fa-check" aria-hidden="true"></i>';
+        pie.appendChild(rosette);
         pie.setAttribute("role", "img");
         pie.setAttribute("aria-label", "Ride fully logged");
         pie.title = "Fully logged — nice one!";
@@ -395,5 +415,6 @@
     ridesNeedingDetails: ridesNeedingDetails,
     nudgeText: nudgeText,
     rideRoute: rideRoute,
+    flagEmoji: flagEmoji,
   };
 });

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3145,7 +3145,10 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
   color: #e0a800;
   font-size: 15px;
   line-height: 1;
+  text-decoration: none;
 }
+a.acct-ride__warn { cursor: pointer; }
+a.acct-ride__warn:hover { color: #b98900; }
 
 /* Completion pie: a conic-gradient sweep whose angle comes from --pct (0-100), with a
    white centre punched out so it reads as a donut rather than a solid disc. */
@@ -3165,6 +3168,31 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
   border-radius: 50%;
   background: #fff;
 }
+/* Below 100% the pie is a link to go fill in the missing details. */
+.acct-pie--cta { cursor: pointer; display: block; }
+.acct-pie--cta:hover { box-shadow: 0 0 0 3px rgba(47, 128, 237, .2); }
+
+/* Awards earned. Locked tiers live on the full /insights page. */
+.acct-awards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.acct-award {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 999px;
+  padding: 4px 10px 4px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #7a5c00;
+  cursor: default;
+}
+.acct-award__emoji { font-size: 14px; line-height: 1; }
 .acct-more {
   align-self: flex-start;
   background: none;

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3158,7 +3158,7 @@ a.acct-ride__warn:hover { color: #b98900; }
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  background: conic-gradient(#2f80ed calc(var(--pct) * 1%), #e6e6e6 0);
+  background: conic-gradient(var(--pie-color, #2f80ed) calc(var(--pct) * 1%), #e6e6e6 0);
   position: relative;
 }
 .acct-pie::after {
@@ -3168,9 +3168,65 @@ a.acct-ride__warn:hover { color: #b98900; }
   border-radius: 50%;
   background: #fff;
 }
-/* Below 100% the pie is a link to go fill in the missing details. */
-.acct-pie--cta { cursor: pointer; display: block; }
-.acct-pie--cta:hover { box-shadow: 0 0 0 3px rgba(47, 128, 237, .2); }
+/* Completeness reads as colour before it reads as a number. --pie-color feeds both the
+   conic sweep and the focus ring, so a tier only has to be stated once. */
+.acct-pie--low  { --pie-color: #e05353; }
+.acct-pie--mid  { --pie-color: #f5a623; }
+.acct-pie--high { --pie-color: #2f80ed; }
+
+/* Below 100% the pie is a link to go fill in the missing details. It breathes gently so
+   the eye lands on it — an invitation, not an alarm. */
+.acct-pie--cta {
+  cursor: pointer;
+  display: block;
+  animation: acct-pie-breathe 2.4s ease-in-out infinite;
+  transition: transform .15s ease;
+}
+.acct-pie--cta:hover {
+  transform: scale(1.12);
+  /* Fallback first: color-mix needs Safari 16.2+, and an unsupported declaration is
+     dropped, leaving this neutral ring rather than no ring at all. */
+  box-shadow: 0 0 0 4px rgba(47, 128, 237, .22);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--pie-color) 25%, transparent);
+  animation: none;
+}
+@keyframes acct-pie-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--pie-color) 35%, transparent); }
+  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, var(--pie-color) 0%, transparent); }
+}
+/* Respect users who asked the OS for less motion. */
+@media (prefers-reduced-motion: reduce) {
+  .acct-pie--cta { animation: none; }
+  .acct-pie--done { animation: none; }
+}
+
+/* 100%: the progress ring becomes a reward. Filling that last field visibly changes the
+   thing, which is the whole point of the pie being a CTA in the first place. */
+.acct-pie--done {
+  background: none;
+  color: #1a9850;
+  font-size: 26px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: acct-done-pop .45s cubic-bezier(.34, 1.56, .64, 1);
+}
+.acct-pie--done::after { content: none; }
+@keyframes acct-done-pop {
+  0%   { transform: scale(.4) rotate(-25deg); opacity: 0; }
+  70%  { transform: scale(1.15) rotate(4deg); }
+  100% { transform: scale(1) rotate(0); opacity: 1; }
+}
+
+/* The count of rides still worth topping up — the pull toward completion. */
+.acct-nudge-line {
+  font-size: 12px;
+  font-weight: 700;
+  color: #2f80ed;
+  margin: -2px 0 8px;
+}
+.acct-nudge-line--done { color: #1a9850; }
 
 /* Awards earned. Locked tiers live on the full /insights page. */
 .acct-awards {

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3209,23 +3209,71 @@ a.acct-ride__warn:hover { color: #b98900; }
   .acct-pie--done { animation: none; }
 }
 
-/* 100%: the progress ring becomes a reward. Filling that last field visibly changes the
-   thing, which is the whole point of the pie being a CTA in the first place. */
+/* 100%: the progress ring becomes a reward — an award ribbon rather than a flat tick.
+   A green rosette holds the check; two ribbon tails fall from beneath it, drawn with
+   clipped pseudo-elements so it costs no image. Filling that last field visibly changes
+   the thing, which is the whole point of the pie being a CTA in the first place. */
 .acct-pie--done {
   background: none;
-  color: #1a9850;
-  font-size: 26px;
-  line-height: 1;
+  overflow: visible;
+  width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: acct-done-pop .45s cubic-bezier(.34, 1.56, .64, 1);
+  animation: acct-done-pop .5s cubic-bezier(.34, 1.56, .64, 1);
 }
 .acct-pie--done::after { content: none; }
+
+/* Ribbon tails, tucked behind the rosette and notched with a clip-path chevron. */
+.acct-pie--done::before {
+  content: "";
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  width: 18px;
+  height: 15px;
+  transform: translateX(-50%);
+  background: linear-gradient(#1e8b4d, #14663a);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 50% 72%, 0 100%);
+  border-radius: 1px;
+  z-index: 0;
+}
+/* The rosette itself: a gold-rimmed green disc holding the tick. */
+.acct-pie--done .acct-rosette {
+  position: relative;
+  z-index: 1;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #46c07a, #1a9850 70%);
+  box-shadow: 0 0 0 2px #ffd15c, 0 1px 3px rgba(0, 0, 0, .3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 11px;
+  line-height: 1;
+}
+/* A brief sheen sweeps the rosette once, the way a medal catches the light. */
+.acct-pie--done .acct-rosette::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: linear-gradient(115deg, transparent 40%, rgba(255, 255, 255, .75) 50%, transparent 60%);
+  animation: acct-sheen 1.6s ease-out .25s 1;
+}
 @keyframes acct-done-pop {
-  0%   { transform: scale(.4) rotate(-25deg); opacity: 0; }
-  70%  { transform: scale(1.15) rotate(4deg); }
+  0%   { transform: scale(.3) rotate(-30deg); opacity: 0; }
+  60%  { transform: scale(1.2) rotate(6deg); }
+  80%  { transform: scale(.96) rotate(-2deg); }
   100% { transform: scale(1) rotate(0); opacity: 1; }
+}
+@keyframes acct-sheen {
+  0%   { transform: translateX(-120%); opacity: 0; }
+  35%  { opacity: 1; }
+  100% { transform: translateX(120%); opacity: 0; }
 }
 
 /* The count of rides still worth topping up — the pull toward completion. */

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3124,20 +3124,35 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
 .acct-rides { list-style: none; margin: 0 0 10px; padding: 0; }
 .acct-ride {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 7px 0;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
   border-bottom: 1px solid #f0f0f0;
   font-size: 13px;
 }
 .acct-ride--hidden { display: none; }
-.acct-ride__when { color: #888; font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.acct-ride__meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.acct-ride__when { color: #333; font-weight: 600; font-variant-numeric: tabular-nums; }
+.acct-ride__stats { color: #888; font-size: 12px; font-variant-numeric: tabular-nums; }
 .acct-ride__stars { color: #f5a623; flex-shrink: 0; }
-.acct-ride__comment {
-  color: #444;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+
+/* Completion pie: a conic-gradient sweep whose angle comes from --pct (0-100), with a
+   white centre punched out so it reads as a donut rather than a solid disc. */
+.acct-pie {
+  --pct: 0;
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: conic-gradient(#2f80ed calc(var(--pct) * 1%), #e6e6e6 0);
+  position: relative;
+}
+.acct-pie::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  background: #fff;
 }
 .acct-more {
   align-self: flex-start;

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3136,6 +3136,17 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
 .acct-ride__stats { color: #888; font-size: 12px; font-variant-numeric: tabular-nums; }
 .acct-ride__stars { color: #f5a623; flex-shrink: 0; }
 
+/* Flag on a ride whose destination was never recorded (give-ups are excluded
+   server-side, so this only ever marks fixable missing data). margin-left:auto pushes
+   it to the trailing edge of the row. */
+.acct-ride__warn {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: #e0a800;
+  font-size: 15px;
+  line-height: 1;
+}
+
 /* Completion pie: a conic-gradient sweep whose angle comes from --pct (0-100), with a
    white centre punched out so it reads as a donut rather than a solid disc. */
 .acct-pie {

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3131,9 +3131,18 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
   font-size: 13px;
 }
 .acct-ride--hidden { display: none; }
-.acct-ride__meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.acct-ride__meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
+/* Where the ride went is its identity; the date is demoted into the small stats line. */
+.acct-ride__route {
+  color: #222;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.acct-ride__route--unknown { color: #aaa; font-weight: 500; font-style: italic; }
 .acct-ride__when { color: #333; font-weight: 600; font-variant-numeric: tabular-nums; }
-.acct-ride__stats { color: #888; font-size: 12px; font-variant-numeric: tabular-nums; }
+.acct-ride__stats { color: #888; font-size: 11.5px; font-variant-numeric: tabular-nums; }
 .acct-ride__stars { color: #f5a623; flex-shrink: 0; }
 
 /* Flag on a ride whose destination was never recorded (give-ups are excluded

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3148,6 +3148,20 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
 .acct-ride__route--fallback { color: #666; font-weight: 500; }
 .acct-ride__when { color: #333; font-weight: 600; font-variant-numeric: tabular-nums; }
 .acct-ride__stats { color: #888; font-size: 11.5px; font-variant-numeric: tabular-nums; }
+.acct-ride__sep { color: #ccc; }
+/* Red = stopped at the roadside (waiting). Green = moving (in the car). */
+.acct-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+.acct-dot--stopped { background: #d73027; }
+.acct-dot--going { background: #1a9850; }
 .acct-ride__stars { color: #f5a623; flex-shrink: 0; }
 
 /* Flag on a ride whose destination was never recorded (give-ups are excluded

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -3131,6 +3131,10 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
   font-size: 13px;
 }
 .acct-ride--hidden { display: none; }
+/* The whole row opens the ride's read-only detail page. */
+.acct-ride--clickable { cursor: pointer; border-radius: 8px; transition: background .12s ease; }
+.acct-ride--clickable:hover { background: #f7f9fc; }
+.acct-ride--clickable:focus-visible { outline: 2px solid #2f80ed; outline-offset: 2px; }
 .acct-ride__meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
 /* Where the ride went is its identity; the date is demoted into the small stats line. */
 .acct-ride__route {
@@ -3140,7 +3144,8 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.acct-ride__route--unknown { color: #aaa; font-weight: 500; font-style: italic; }
+/* No place names yet: the date carries the row, styled a shade quieter than a real route. */
+.acct-ride__route--fallback { color: #666; font-weight: 500; }
 .acct-ride__when { color: #333; font-weight: 600; font-variant-numeric: tabular-nums; }
 .acct-ride__stats { color: #888; font-size: 11.5px; font-variant-numeric: tabular-nums; }
 .acct-ride__stars { color: #f5a623; flex-shrink: 0; }
@@ -3148,13 +3153,15 @@ body.routing-active .leaflet-control-container .leaflet-control-geocoder { displ
 /* Flag on a ride whose destination was never recorded (give-ups are excluded
    server-side, so this only ever marks fixable missing data). margin-left:auto pushes
    it to the trailing edge of the row. */
+/* Lives inline in the route, where the destination should have been. */
+.acct-ride__arrow { color: #bbb; }
+.acct-ride__gaveup { color: #999; font-weight: 500; font-style: italic; }
 .acct-ride__warn {
-  margin-left: auto;
-  flex-shrink: 0;
   color: #e0a800;
-  font-size: 15px;
+  font-size: 13px;
   line-height: 1;
   text-decoration: none;
+  vertical-align: baseline;
 }
 a.acct-ride__warn { cursor: pointer; }
 a.acct-ride__warn:hover { color: #b98900; }

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -305,6 +305,20 @@ html {
 .account-dot--red {
   background: #e53935;
 }
+/* Logged in, but some rides want more detail. Amber, not red: an invitation to enrich,
+   not an error. Pulses once on arrival to draw the eye, then settles. */
+.account-dot--amber {
+  background: #f5a623;
+  animation: account-dot-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes account-dot-pop {
+  0% { transform: scale(0); }
+  70% { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .account-dot--amber { animation: none; }
+}
 
 .top-account-btn a {
   color: #555;

--- a/hitch/static/style.css
+++ b/hitch/static/style.css
@@ -306,8 +306,25 @@ html {
   background: #e53935;
 }
 /* Logged in, but some rides want more detail. Amber, not red: an invitation to enrich,
-   not an error. Pulses once on arrival to draw the eye, then settles. */
+   not an error. Big enough to carry the count (capped at "99+" so the width is bounded);
+   a pill for multi-digit counts, a circle for one. Pulses once on arrival, then settles. */
 .account-dot--amber {
+  width: auto;
+  height: 16px;
+  min-width: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  top: -3px;
+  right: -3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-variant-numeric: tabular-nums;
   background: #f5a623;
   animation: account-dot-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
 }

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -108,3 +108,21 @@ test("nudgeText pluralises and rewards a clean sheet", () => {
   assert.strictEqual(A.nudgeText(1), "1 ride could use more detail");
   assert.strictEqual(A.nudgeText(4), "4 rides could use more detail");
 });
+
+test("rideRoute labels a ride by where it went, degrading gracefully", () => {
+  assert.strictEqual(A.rideRoute({ from_place: "Metzeral", to_place: "Mitte" }), "Metzeral → Mitte");
+  // A give-up has no destination.
+  assert.strictEqual(A.rideRoute({ from_place: "Metzeral" }), "Metzeral");
+  assert.strictEqual(A.rideRoute({ to_place: "Mitte" }), "→ Mitte");
+  // Not geocoded yet (cron hasn't run) -> empty, so the UI shows its fallback.
+  assert.strictEqual(A.rideRoute({}), "");
+  assert.strictEqual(A.rideRoute({ from_place: "  ", to_place: null }), "");
+});
+
+test("rideStats leads with the date, then wait and distance", () => {
+  assert.deepStrictEqual(
+    A.rideStats({ created: "2026-07-28 12:00", wait_min: 45, distance_km: 138.9 }),
+    ["2026-07-28", "45 min", "139 km"]
+  );
+  assert.deepStrictEqual(A.rideStats({ created: "2026-07-28 12:00" }), ["2026-07-28"]);
+});

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -42,3 +42,24 @@ test("rideLabel tolerates a ride with no rating or comment", () => {
   assert.strictEqual(r.stars, "");
   assert.strictEqual(r.comment, "");
 });
+
+test("rideStats formats wait and distance, omitting what wasn't recorded", () => {
+  assert.deepStrictEqual(A.rideStats({ wait_min: 45, distance_km: 138.9 }), ["45 min", "139 km"]);
+  // Over an hour reads as hours + minutes.
+  assert.deepStrictEqual(A.rideStats({ wait_min: 95, distance_km: 5312.4 }), ["1 h 35 m", "5,312 km"]);
+  // null means "not recorded" — omit it rather than print a misleading 0.
+  assert.deepStrictEqual(A.rideStats({ wait_min: null, distance_km: 12 }), ["12 km"]);
+  assert.deepStrictEqual(A.rideStats({ wait_min: 20, distance_km: null }), ["20 min"]);
+  assert.deepStrictEqual(A.rideStats({}), []);
+  // A real zero wait is data, not absence, so it must still render.
+  assert.deepStrictEqual(A.rideStats({ wait_min: 0 }), ["0 min"]);
+});
+
+test("completionPct rounds and clamps, defaulting to 0 when absent", () => {
+  assert.strictEqual(A.completionPct({ completion: 100 }), 100);
+  assert.strictEqual(A.completionPct({ completion: 24.6 }), 25);
+  assert.strictEqual(A.completionPct({ completion: 0 }), 0);
+  assert.strictEqual(A.completionPct({}), 0);
+  assert.strictEqual(A.completionPct({ completion: 140 }), 100);
+  assert.strictEqual(A.completionPct({ completion: -5 }), 0);
+});

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -43,16 +43,18 @@ test("rideLabel tolerates a ride with no rating or comment", () => {
   assert.strictEqual(r.comment, "");
 });
 
+const texts = (entries) => entries.map((e) => e.text);
+
 test("rideStats formats wait and distance, omitting what wasn't recorded", () => {
-  assert.deepStrictEqual(A.rideStats({ wait_min: 45, distance_km: 138.9 }), ["45 min", "139 km"]);
+  assert.deepStrictEqual(texts(A.rideStats({ wait_min: 45, distance_km: 138.9 })), ["45 min", "139 km"]);
   // Over an hour reads as hours + minutes.
-  assert.deepStrictEqual(A.rideStats({ wait_min: 95, distance_km: 5312.4 }), ["1 h 35 m", "5,312 km"]);
+  assert.deepStrictEqual(texts(A.rideStats({ wait_min: 95, distance_km: 5312.4 })), ["1 h 35 m", "5,312 km"]);
   // null means "not recorded" — omit it rather than print a misleading 0.
-  assert.deepStrictEqual(A.rideStats({ wait_min: null, distance_km: 12 }), ["12 km"]);
-  assert.deepStrictEqual(A.rideStats({ wait_min: 20, distance_km: null }), ["20 min"]);
+  assert.deepStrictEqual(texts(A.rideStats({ wait_min: null, distance_km: 12 })), ["12 km"]);
+  assert.deepStrictEqual(texts(A.rideStats({ wait_min: 20, distance_km: null })), ["20 min"]);
   assert.deepStrictEqual(A.rideStats({}), []);
   // A real zero wait is data, not absence, so it must still render.
-  assert.deepStrictEqual(A.rideStats({ wait_min: 0 }), ["0 min"]);
+  assert.deepStrictEqual(texts(A.rideStats({ wait_min: 0 })), ["0 min"]);
 });
 
 test("completionPct rounds and clamps, defaulting to 0 when absent", () => {
@@ -121,10 +123,10 @@ test("rideRoute labels a ride by where it went, degrading gracefully", () => {
 
 test("rideStats leads with the date, then wait and distance", () => {
   assert.deepStrictEqual(
-    A.rideStats({ created: "2026-07-28 12:00", wait_min: 45, distance_km: 138.9 }),
+    texts(A.rideStats({ created: "2026-07-28 12:00", wait_min: 45, distance_km: 138.9 })),
     ["2026-07-28", "45 min", "139 km"]
   );
-  assert.deepStrictEqual(A.rideStats({ created: "2026-07-28 12:00" }), ["2026-07-28"]);
+  assert.deepStrictEqual(texts(A.rideStats({ created: "2026-07-28 12:00" })), ["2026-07-28"]);
 });
 
 test("flagEmoji maps an ISO alpha-2 code to regional indicators", () => {
@@ -179,9 +181,9 @@ test("rideTitle falls back to the date when no place names exist yet", () => {
 
 test("rideStats omits the date when the date is already the title", () => {
   const ride = { created: "2026-07-28 12:00", wait_min: 45, distance_km: 138.9 };
-  assert.deepStrictEqual(A.rideStats(ride, true), ["2026-07-28", "45 min", "139 km"]);
+  assert.deepStrictEqual(texts(A.rideStats(ride, true)), ["2026-07-28", "45 min", "139 km"]);
   // Date serving as the title -> don't repeat it below.
-  assert.deepStrictEqual(A.rideStats(ride, false), ["45 min", "139 km"]);
+  assert.deepStrictEqual(texts(A.rideStats(ride, false)), ["45 min", "139 km"]);
 });
 
 test("routeSegments distinguishes a known, missing and never-reached destination", () => {
@@ -229,4 +231,24 @@ test("rideViewUrl links every ride, editable or not", () => {
   assert.strictEqual(A.rideViewUrl({ type: "own", d_tag: "a b&c" }), "/ride/a%20b%26c");
   // No d_tag -> nothing to open.
   assert.strictEqual(A.rideViewUrl({ type: "own" }), null);
+});
+
+test("rideStats tags wait as stopped (red) and ride time as going (green)", () => {
+  const entries = A.rideStats({ created: "2026-07-28 12:00", wait_min: 45, ride_min: 140, distance_km: 138.9 });
+  assert.deepStrictEqual(entries, [
+    { text: "2026-07-28", dot: null },
+    { text: "45 min", dot: "stopped" },
+    { text: "2 h 20 m", dot: "going" },
+    { text: "139 km", dot: null },
+  ]);
+});
+
+test("rideStats silently omits a ride time the record never carried", () => {
+  // The historic form doesn't record arrival, so most rides have no duration at all.
+  const entries = A.rideStats({ wait_min: 45, ride_min: null, distance_km: 10 });
+  assert.deepStrictEqual(entries.map((e) => e.dot), ["stopped", null]);
+  // Nothing recorded at all -> nothing rendered, no empty dots.
+  assert.deepStrictEqual(A.rideStats({ created: "" }), []);
+  // A zero-minute ride is data, not absence.
+  assert.deepStrictEqual(A.rideStats({ ride_min: 0 }), [{ text: "0 min", dot: "going" }]);
 });

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -63,3 +63,19 @@ test("completionPct rounds and clamps, defaulting to 0 when absent", () => {
   assert.strictEqual(A.completionPct({ completion: 140 }), 100);
   assert.strictEqual(A.completionPct({ completion: -5 }), 0);
 });
+
+test("rideEditUrl only links rides the user can actually edit", () => {
+  // /ride?edit= only prefills for rides we published — type "own".
+  assert.strictEqual(A.rideEditUrl({ type: "own", d_tag: "abc" }), "/ride?edit=abc");
+  // Imported from another source: the edit form would not prefill, so no dead link.
+  assert.strictEqual(A.rideEditUrl({ type: "own_external", d_tag: "abc" }), null);
+  assert.strictEqual(A.rideEditUrl({ type: "co_hitchhiker", d_tag: "abc" }), null);
+  assert.strictEqual(A.rideEditUrl({ type: "own" }), null);
+  // d_tags come from Nostr and are not URL-safe by construction.
+  assert.strictEqual(A.rideEditUrl({ type: "own", d_tag: "a b&c" }), "/ride?edit=a%20b%26c");
+});
+
+test("awardsSummary pluralises", () => {
+  assert.strictEqual(A.awardsSummary(1), "1 award earned");
+  assert.strictEqual(A.awardsSummary(3), "3 awards earned");
+});

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -126,3 +126,23 @@ test("rideStats leads with the date, then wait and distance", () => {
   );
   assert.deepStrictEqual(A.rideStats({ created: "2026-07-28 12:00" }), ["2026-07-28"]);
 });
+
+test("flagEmoji maps an ISO alpha-2 code to regional indicators", () => {
+  assert.strictEqual(A.flagEmoji("FR"), "🇫🇷");
+  assert.strictEqual(A.flagEmoji("de"), "🇩🇪");
+  // Anything that isn't two ASCII letters must not produce stray glyphs.
+  assert.strictEqual(A.flagEmoji(""), "");
+  assert.strictEqual(A.flagEmoji(null), "");
+  assert.strictEqual(A.flagEmoji("USA"), "");
+  assert.strictEqual(A.flagEmoji("1A"), "");
+});
+
+test("rideRoute prefixes each place with its country flag", () => {
+  assert.strictEqual(
+    A.rideRoute({ from_place: "Metzeral", from_cc: "FR", to_place: "Mitte", to_cc: "DE" }),
+    "🇫🇷 Metzeral → 🇩🇪 Mitte"
+  );
+  // No country code (older generated file) -> just the name, no gap.
+  assert.strictEqual(A.rideRoute({ from_place: "Metzeral", to_place: "Mitte" }), "Metzeral → Mitte");
+  assert.strictEqual(A.rideRoute({ from_place: "Metzeral", from_cc: "FR" }), "🇫🇷 Metzeral");
+});

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -146,3 +146,87 @@ test("rideRoute prefixes each place with its country flag", () => {
   assert.strictEqual(A.rideRoute({ from_place: "Metzeral", to_place: "Mitte" }), "Metzeral → Mitte");
   assert.strictEqual(A.rideRoute({ from_place: "Metzeral", from_cc: "FR" }), "🇫🇷 Metzeral");
 });
+
+test("formatRideDate renders dd - month - yy hh:mm", () => {
+  assert.strictEqual(A.formatRideDate("2026-07-28 12:00"), "28 - July - 26 12:00");
+  assert.strictEqual(A.formatRideDate("2026-01-05T09:30:00Z"), "5 - January - 26 09:30");
+  // Date only, no time component.
+  assert.strictEqual(A.formatRideDate("2026-12-31"), "31 - December - 26");
+  // Garbage in, nothing out — never "NaN - undefined".
+  assert.strictEqual(A.formatRideDate(""), "");
+  assert.strictEqual(A.formatRideDate(null), "");
+  assert.strictEqual(A.formatRideDate("not a date"), "");
+  assert.strictEqual(A.formatRideDate("2026-13-01"), "");
+});
+
+test("formatRideDate does not shift the day across timezones", () => {
+  // new Date("2026-07-28 00:30") would be re-read in the browser's zone and could land on
+  // the 27th. `created` is already local submission time, so it is parsed literally.
+  assert.strictEqual(A.formatRideDate("2026-07-28 00:30"), "28 - July - 26 00:30");
+  assert.strictEqual(A.formatRideDate("2026-07-28 23:45"), "28 - July - 26 23:45");
+});
+
+test("rideTitle falls back to the date when no place names exist yet", () => {
+  assert.strictEqual(
+    A.rideTitle({ from_place: "Metzeral", from_cc: "FR", to_place: "Mitte", to_cc: "DE", created: "2026-07-28 12:00" }),
+    "🇫🇷 Metzeral → 🇩🇪 Mitte"
+  );
+  // Not geocoded yet -> the date identifies the ride.
+  assert.strictEqual(A.rideTitle({ created: "2026-07-28 12:00" }), "28 - July - 26 12:00");
+  // Neither -> a last-resort label, never an empty row.
+  assert.strictEqual(A.rideTitle({}), "Unknown ride");
+});
+
+test("rideStats omits the date when the date is already the title", () => {
+  const ride = { created: "2026-07-28 12:00", wait_min: 45, distance_km: 138.9 };
+  assert.deepStrictEqual(A.rideStats(ride, true), ["2026-07-28", "45 min", "139 km"]);
+  // Date serving as the title -> don't repeat it below.
+  assert.deepStrictEqual(A.rideStats(ride, false), ["45 min", "139 km"]);
+});
+
+test("routeSegments distinguishes a known, missing and never-reached destination", () => {
+  // Known destination.
+  assert.deepStrictEqual(
+    A.routeSegments({ from_place: "Metzeral", from_cc: "FR", to_place: "Mitte", to_cc: "DE" }),
+    { start: "🇫🇷 Metzeral", end: "🇩🇪 Mitte", endKind: "place" }
+  );
+  // Real ride, no destination recorded -> fixable, rendered as an inline warning.
+  assert.deepStrictEqual(
+    A.routeSegments({ from_place: "Metzeral", from_cc: "FR", missing_destination: true }),
+    { start: "🇫🇷 Metzeral", end: "", endKind: "missing" }
+  );
+  // Give-up: never picked up, so no destination is correct. Not an error.
+  assert.deepStrictEqual(
+    A.routeSegments({ from_place: "Soultzeren", from_cc: "FR", gave_up: true }),
+    { start: "🇫🇷 Soultzeren", end: "gave up", endKind: "gaveup" }
+  );
+  // A give-up must never be flagged as missing, even if both flags somehow arrived.
+  assert.strictEqual(
+    A.routeSegments({ from_place: "X", gave_up: true, missing_destination: true }).endKind,
+    "gaveup"
+  );
+});
+
+test("routeSegments falls back to the date when the origin isn't geocoded", () => {
+  // No place names yet: the date carries the row, and the arrow must not dangle.
+  assert.deepStrictEqual(
+    A.routeSegments({ created: "2026-07-28 12:00" }),
+    { start: "28 - July - 26 12:00", end: "", endKind: null }
+  );
+  // Still flags a missing destination even without an origin name.
+  assert.strictEqual(
+    A.routeSegments({ created: "2026-07-28 12:00", missing_destination: true }).endKind,
+    "missing"
+  );
+});
+
+test("rideViewUrl links every ride, editable or not", () => {
+  // The detail page is public, so even rides the user cannot edit are viewable.
+  assert.strictEqual(A.rideViewUrl({ type: "own", d_tag: "abc" }), "/ride/abc");
+  assert.strictEqual(A.rideViewUrl({ type: "own_external", d_tag: "abc" }), "/ride/abc");
+  assert.strictEqual(A.rideViewUrl({ type: "co_hitchhiker", d_tag: "abc" }), "/ride/abc");
+  // d_tags come from Nostr and are not URL-safe by construction.
+  assert.strictEqual(A.rideViewUrl({ type: "own", d_tag: "a b&c" }), "/ride/a%20b%26c");
+  // No d_tag -> nothing to open.
+  assert.strictEqual(A.rideViewUrl({ type: "own" }), null);
+});

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -79,3 +79,32 @@ test("awardsSummary pluralises", () => {
   assert.strictEqual(A.awardsSummary(1), "1 award earned");
   assert.strictEqual(A.awardsSummary(3), "3 awards earned");
 });
+
+test("completionTier maps a percentage to a colour band", () => {
+  assert.strictEqual(A.completionTier(0), "low");
+  assert.strictEqual(A.completionTier(33), "low");
+  assert.strictEqual(A.completionTier(34), "mid");
+  assert.strictEqual(A.completionTier(66), "mid");
+  assert.strictEqual(A.completionTier(67), "high");
+  assert.strictEqual(A.completionTier(99), "high");
+  // 100 stops being a progress bar and becomes a badge.
+  assert.strictEqual(A.completionTier(100), "done");
+});
+
+test("ridesNeedingDetails counts only rides the user can actually fix", () => {
+  const rides = [
+    { type: "own", d_tag: "a", completion: 100 },                          // done
+    { type: "own", d_tag: "b", completion: 40 },                           // incomplete
+    { type: "own", d_tag: "c", completion: 100, missing_destination: true }, // complete but no dest
+    { type: "own_external", d_tag: "d", completion: 0 },                   // not editable
+    { type: "co_hitchhiker", d_tag: "e", completion: 0 },                  // not editable
+  ];
+  assert.strictEqual(A.ridesNeedingDetails(rides), 2);
+  assert.strictEqual(A.ridesNeedingDetails([]), 0);
+});
+
+test("nudgeText pluralises and rewards a clean sheet", () => {
+  assert.strictEqual(A.nudgeText(0), "Every ride is fully logged. Nice.");
+  assert.strictEqual(A.nudgeText(1), "1 ride could use more detail");
+  assert.strictEqual(A.nudgeText(4), "4 rides could use more detail");
+});

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -252,3 +252,14 @@ test("rideStats silently omits a ride time the record never carried", () => {
   // A zero-minute ride is data, not absence.
   assert.deepStrictEqual(A.rideStats({ ride_min: 0 }), [{ text: "0 min", dot: "going" }]);
 });
+
+test("badgeCount shows the number and caps at 99+", () => {
+  assert.strictEqual(A.badgeCount(1), "1");
+  assert.strictEqual(A.badgeCount(8), "8");
+  assert.strictEqual(A.badgeCount(99), "99");
+  assert.strictEqual(A.badgeCount(100), "99+");
+  assert.strictEqual(A.badgeCount(1247), "99+");
+  // Nothing to show below 1.
+  assert.strictEqual(A.badgeCount(0), "");
+  assert.strictEqual(A.badgeCount(-3), "");
+});

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -237,3 +237,26 @@ def test_ride_duration_is_time_moving_and_never_wrong():
     # Clock skew: arrival before departure must never render as a negative duration.
     skewed = [{"departure_time": "2026-07-28T14:20:00"}, {"arrival_time": "2026-07-28T12:00:00"}]
     assert _ride_duration_minutes(ride(skewed)) is None
+
+
+def test_incomplete_rides_count_matches_the_modal_rule():
+    """The avatar nudge dot and the modal must agree on what "needs detail" means."""
+    from hitch.blueprints.user import _ride_needs_detail
+
+    # Editable + incomplete -> counts.
+    assert _ride_needs_detail({"type": "own", "completion": 40, "missing_destination": False}) is True
+    # Editable + complete but no destination -> counts (the ⚠ case).
+    assert _ride_needs_detail({"type": "own", "completion": 100, "missing_destination": True}) is True
+    # Editable + fully complete -> does not count.
+    assert _ride_needs_detail({"type": "own", "completion": 100, "missing_destination": False}) is False
+    # Not editable -> never counts, however incomplete (no way to fix it).
+    assert _ride_needs_detail({"type": "own_external", "completion": 0, "missing_destination": True}) is False
+    assert _ride_needs_detail({"type": "co_hitchhiker", "completion": 0, "missing_destination": False}) is False
+
+
+def test_incomplete_rides_endpoint_anonymous_is_zero_not_a_redirect(client):
+    resp = client.get("/me/incomplete_rides.json")
+    assert resp.status_code == 200  # never 302 to /login
+    assert resp.get_json() == {"count": 0}
+    assert "public" not in resp.headers.get("Cache-Control", "")
+    assert "no-store" in resp.headers.get("Cache-Control", "")

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -183,3 +183,32 @@ def test_me_json_carries_only_earned_achievements(client, logged_in_user):
     for award in awards:
         assert set(award) == {"emoji", "name", "blurb"}
         assert award["emoji"] and award["name"]
+
+
+def test_ride_places_lookup_is_bounded_to_the_rides_asked_for(app, db):
+    """Place names come from a table, looked up by the d_tags being rendered.
+
+    The first implementation cached the whole corpus as a JSON blob; at ~70 000 rides that
+    is ~7 MB on disk and ~33 MB of parsed dict resident in *every* waitress worker, to
+    answer a question about 50 rides. This pins the bounded behaviour.
+    """
+    from hitch.blueprints.user import _ride_places
+    from hitch.models import RidePlace
+
+    with app.app_context():
+        db.session.add(RidePlace(d_tag="a", from_place="Metzeral", from_cc="FR", to_place="Mitte", to_cc="DE"))
+        db.session.add(RidePlace(d_tag="b", from_place="Milano", from_cc="IT"))
+        db.session.commit()
+
+        found = _ride_places(["a", "missing"])
+        # Only what was asked for, and a miss is simply absent rather than an error.
+        assert set(found) == {"a"}
+        assert found["a"].from_place == "Metzeral"
+        assert found["a"].to_cc == "DE"
+
+        # A ride with no destination stores only its origin.
+        assert _ride_places(["b"])["b"].to_place is None
+
+        # No d_tags -> no query at all.
+        assert _ride_places([]) == {}
+        assert _ride_places([None]) == {}

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -212,3 +212,28 @@ def test_ride_places_lookup_is_bounded_to_the_rides_asked_for(app, db):
         # No d_tags -> no query at all.
         assert _ride_places([]) == {}
         assert _ride_places([None]) == {}
+
+
+def test_ride_duration_is_time_moving_and_never_wrong():
+    """Ride time = last arrival - first departure. Distinct from wait (time stopped)."""
+    from types import SimpleNamespace
+
+    from hitch.blueprints.user import _ride_duration_minutes
+
+    def ride(stops):
+        return SimpleNamespace(content={"stops": stops})
+
+    dep = {"departure_time": "2026-07-28T12:00:00"}
+    arr = {"arrival_time": "2026-07-28T14:20:00"}
+    assert _ride_duration_minutes(ride([dep, arr])) == 140
+
+    # Any missing/unparseable piece -> None, so the UI omits it rather than guessing.
+    assert _ride_duration_minutes(ride([dep, {}])) is None
+    assert _ride_duration_minutes(ride([{}, arr])) is None
+    assert _ride_duration_minutes(ride([dep])) is None
+    assert _ride_duration_minutes(ride([])) is None
+    assert _ride_duration_minutes(ride([{"departure_time": "nope"}, {"arrival_time": "nah"}])) is None
+
+    # Clock skew: arrival before departure must never render as a negative duration.
+    skewed = [{"departure_time": "2026-07-28T14:20:00"}, {"arrival_time": "2026-07-28T12:00:00"}]
+    assert _ride_duration_minutes(ride(skewed)) is None

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -160,3 +160,26 @@ def test_missing_destination_is_flagged_but_give_ups_are_not():
     # Give-up (no_ride present), no destination -> NOT flagged.
     gave_up = ride(stops=[start], no_ride={"reasons": []})
     assert _extract_ride_info(gave_up, "own")["missing_destination"] is False
+
+
+def test_me_json_carries_only_earned_achievements(client, logged_in_user):
+    """The modal celebrates earned tiers; locked ones stay on the /insights page.
+
+    The fixture user has 42 rides and 5312 km, so they clear "Thumb Warmer" (5 rides),
+    "Out of Town" (100 km) and "Continental Drifter" (1000 km), but not the 100-ride or
+    10 000-km tiers.
+    """
+    body = client.get("/me.json").get_json()
+    awards = body["achievements"]
+    names = [a["name"] for a in awards]
+
+    assert "Thumb Warmer" in names
+    assert "Out of Town" in names
+    assert "Continental Drifter" in names
+    # Not yet earned -> must not appear.
+    assert "Roadside Regular" not in names
+    assert "Quarter Way Round the World" not in names
+
+    for award in awards:
+        assert set(award) == {"emoji", "name", "blurb"}
+        assert award["emoji"] and award["name"]

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -85,3 +85,51 @@ def test_me_json_logged_in_is_still_not_publicly_cacheable(client, logged_in_use
     resp = client.get("/me.json")
     assert "public" not in resp.headers.get("Cache-Control", "")
     assert "no-store" in resp.headers.get("Cache-Control", "")
+
+
+def test_ride_rows_carry_completion_wait_and_distance():
+    """The modal's ride list needs a completion score, wait and distance per ride.
+
+    Completion reuses the canonical ride_score weights, so a fully-detailed ride is 100%
+    and one with only gender (15) + vehicle kind (10) is 25%.
+    """
+    from types import SimpleNamespace
+
+    from hitch.blueprints.user import _extract_ride_info
+
+    stops = [
+        {"location": {"latitude": 48.0, "longitude": 7.0}, "waiting_duration": "PT45M"},
+        {"location": {"latitude": 49.0, "longitude": 7.0}},
+    ]
+
+    def ride(**content):
+        return SimpleNamespace(content=content, d="t", rating=4, comment="", submission_time="2026-07-01T12:00:00Z")
+
+    full = ride(
+        stops=stops,
+        occupants=[
+            {
+                "was_driver": True,
+                "gender": "female",
+                "year_of_birth": 1980,
+                "origin_country": "DE",
+                "languages": ["deu"],
+                "reasons_to_pick_up": ["curiosity"],
+            }
+        ],
+        mode_of_transportation={"kind": "car", "license_plate_country": "DE"},
+    )
+    info = _extract_ride_info(full, "own")
+    assert info["completion"] == 100
+    assert info["wait_min"] == 45
+    # 1 degree of latitude, scaled by show.py's 1.25 road-detour factor.
+    assert info["distance_km"] == 138.9
+
+    partial = ride(stops=stops, occupants=[{"was_driver": True, "gender": "female"}], mode_of_transportation={"kind": "car"})
+    assert _extract_ride_info(partial, "own")["completion"] == 25
+
+    # No destination and no wait recorded -> None, so the UI omits them.
+    bare = _extract_ride_info(ride(stops=[stops[0] | {"waiting_duration": ""}]), "own")
+    assert bare["completion"] == 0
+    assert bare["wait_min"] is None
+    assert bare["distance_km"] is None

--- a/tests/test_me_json.py
+++ b/tests/test_me_json.py
@@ -133,3 +133,30 @@ def test_ride_rows_carry_completion_wait_and_distance():
     assert bare["completion"] == 0
     assert bare["wait_min"] is None
     assert bare["distance_km"] is None
+
+
+def test_missing_destination_is_flagged_but_give_ups_are_not():
+    """A ride with no destination is fixable data -> flag it.
+
+    A `no_ride` record is a give-up: the hitchhiker was never picked up, so having no
+    destination is correct and must not raise a false alarm.
+    """
+    from types import SimpleNamespace
+
+    from hitch.blueprints.user import _extract_ride_info
+
+    start = {"location": {"latitude": 48.0, "longitude": 7.0}}
+    end = {"location": {"latitude": 49.0, "longitude": 7.0}}
+
+    def ride(**content):
+        return SimpleNamespace(content=content, d="t", rating=0, comment="", submission_time="2026-07-01T12:00:00Z")
+
+    # Real ride, destination recorded -> no flag.
+    assert _extract_ride_info(ride(stops=[start, end]), "own")["missing_destination"] is False
+
+    # Real ride, no destination -> flag.
+    assert _extract_ride_info(ride(stops=[start]), "own")["missing_destination"] is True
+
+    # Give-up (no_ride present), no destination -> NOT flagged.
+    gave_up = ride(stops=[start], no_ride={"reasons": []})
+    assert _extract_ride_info(gave_up, "own")["missing_destination"] is False


### PR DESCRIPTION
Closes #109. Builds on the account modal merged in #107.

## Why

#101 made logging a ride *well* feel natural **while it's happening**. But most rides in the database predate that, or were logged in a hurry and left thin — and nothing tells a hitchhiker which of their past rides are incomplete, what's missing, or why it's worth fixing. Every row in the account modal looked identical whether it carried a full driver/vehicle profile or nothing but a rating.

The data we're missing is exactly the data that makes the map useful to everyone else: who picks people up, what they drive, how long the wait really was, where the ride actually ended.

This makes the state of your own ride history legible, and makes improving it feel worth doing.

## What a ride row looks like now

```
🎀  🇫🇷 Metzeral → 🇩🇪 Schweighofen        ← fully logged: ribbon badge
    28 - July - 26 · 🔴 5 min · 🟢 1 h 35 m · 167 km

◔   🇫🇷 Soultzeren → ⚠                    ← 40%: amber pie (CTA), missing destination (CTA)
    27 - July - 26 · 🔴 14 min

◕   🇫🇷 Bischoffsheim → gave up            ← never picked up: a fact, not an error
    23 - July - 26 · 🔴 50 min
```

- **Completion pie** per ride, coloured red → amber → blue by tier, driven by the canonical `ride_score_weights.json` so the number matches the meters the in-ride sheet showed while logging. Below 100% it's a CTA into the edit form.
- **At 100% the pie becomes an award ribbon** — a rosette that pops and catches the light. Filling the last field visibly changes the thing that was prodding you. That's the reward.
- **"8 rides could use more detail"** above the list, or a clean-sheet reward when there's nothing left. Counts only rides the user can actually edit.
- **Missing destination is inline**, where the destination should have been: `→ ⚠`, clickable straight to the fix.
- **Rides are identified by place, not timestamp.** The date is demoted to the stats line — and takes over as the title when a ride isn't geocoded yet.
- **Two durations, distinguished**: red dot = stopped at the roadside, green dot = moving.
- **Earned awards** surfaced from the same ladders `/insights` renders. Only earned tiers.
- **Every row opens its read-only detail page** — including complete ones, which have no CTA of their own.

## Correctness decisions worth reviewing

- **A give-up is not an error.** A `no_ride` record has no destination *by design*; flagging it would fire a false alarm on every give-up ever logged. `missing_destination = no destination AND not a give-up`, decided server-side. A give-up wins the branch outright, asserted by test.
- **The flag keys on `destination_lat`, not on `distance_km` being null.** Those look interchangeable but aren't: the distance helper also returns null for a sub-1 km ride, which *does* have a destination.
- **CTAs only render on rides the user can edit** (`type == "own"`). `/ride?edit=` prefills only when `_user_owns_ride` passes, so an imported or co-hitchhiker ride would have gotten a dead link. Those keep a plain indicator. The read-only detail page is public, so *every* row is still clickable.
- **Ride time returns null for clock skew**, missing/unparseable timestamps, and single-stop rides — never a negative duration.
- **Null means "not recorded" and is silently omitted**; a genuine zero is data and still renders.
- **Dates are parsed by hand, not with `new Date()`** — `created` is already local submission time, and re-reading it in the browser's zone could shift a 00:30 ride onto the previous day.
- **Flags reject anything that isn't two ASCII letters**, so no stray regional-indicator glyphs.
- Links open in a **new tab with `rel=noopener`**: the modal exists so the map never unloads.

## Infrastructure: the `ride_place` table

Place names need reverse geocoding, and that's where the interesting constraint is.

`reverse_geocoder` costs **~150 MB resident** once its index builds (measured), answering in 0.1 ms warm. Loading that into every waitress worker on a host the OOM killer has already visited (CLAUDE.md) is not worth a city name. So it runs offline and the app reads only what it needs.

- New **`ride_place` table**, keyed by the ride's Nostr `d` tag; `/me.json` looks up only the d_tags it's rendering.
- **A separate table, not columns on `ride_event`** — `fetch_nostr` deletes and rebuilds `ride_event` wholesale every 30 min, destroying the names twice an hour. A new table also needs **no manual `ALTER`**: `create_all` creates tables, it just can't add columns.
- **Incremental**: only rides absent from the table are geocoded, so a steady-state run resolves nothing and never builds the index. Verified — cold run geocodes, second run reports "Nothing new to geocode."
- **Zero network cost.** The package bundles its 7.5 MB dataset and only fetches from geonames.org if it's missing — proven by geocoding with `socket.socket` patched to raise.

I first shipped this as a `dist/ride_places.json` blob. Against the real **69,525 rides** that's ~7 MB on disk and **~33 MB of parsed dict resident per worker**, to answer a question about 50 rides. `187872e` replaces it with the table, and there's a test pinning the lookup to only the d_tags asked for so nobody reintroduces the corpus-wide cache. `show.py` can later join this table to bake the same labels into `rides_index.json` and the per-spot files.

## ⚠️ Deployment step

`hitch/scripts/` is baked into the image, not bind-mounted. After the rebuild, run the backfill **once** for the 69k existing rides:

```bash
sudo docker exec hitchhiking-map /usr/local/bin/flask --app hitch generate ride_places
```

Until then rides render with the date as their title instead of place names — degrading, not breaking. A daily cron entry (04:45) keeps it fresh afterwards.

## Testing

- **node 38/38** — tier boundaries (33/34, 66/67, 99/100), give-up precedence over missing-destination, date parsing across midnight, stats de-duplication, flag rejection of `"USA"`/`"1A"`/null, `d_tag` URL-encoding, CTA gating by ride type.
- **pytest 52** — completion scoring at 100/25/0, distance against `show.py`'s road factor, wait/duration null-vs-zero, clock skew, earned-vs-locked award boundary, and the bounded `ride_place` lookup.
- **ruff** clean.
- Verified live against seeded rides covering every state: complete, partial, missing destination, give-up, geocoded and not, with and without timestamps.

## Out of scope

Editing still hands off to the existing `/ride?edit=` form in a new tab. Reusing the in-ride details card for after-the-fact editing, with a Ride tab for location/time fields, is tracked in #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)